### PR TITLE
Simplify `_sort_and_group` and freeze requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
+colorama==0.4.3
+commonmark==0.9.1
+pprintpp==0.4.0
+Pygments==2.6.1
 pytz==2020.1
 rich==5.0.0
+typing-extensions==3.7.4.2

--- a/timezone_converter.py
+++ b/timezone_converter.py
@@ -74,7 +74,7 @@ class TimezonesList(Helper):
     def _sort_and_group(self):
         pairs = [(k, v) for k, v in self.timezone_translations.items()]
         sorted_timezones = dict(sorted([pair for pair in pairs if pair[0]]))
-        biggest_name = max({len(k) for k in sorted_timezones})
+        biggest_name = len(max(sorted_timezones, key=lambda x: len(x)))
         timezone_groups = {letter: [] for letter in ascii_lowercase}
         for k in sorted_timezones:
             timezone_groups[k[0]].append(k.center(biggest_name))

--- a/timezone_converter.py
+++ b/timezone_converter.py
@@ -1,7 +1,7 @@
 import argparse
+from collections import defaultdict
 from datetime import datetime
 from datetime import timedelta
-from string import ascii_lowercase
 
 import pytz
 from rich.columns import Columns
@@ -74,10 +74,10 @@ class TimezonesList(Helper):
     def _sort_and_group(self):
         pairs = [(k, v) for k, v in self.timezone_translations.items()]
         sorted_timezones = dict(sorted([pair for pair in pairs if pair[0]]))
-        biggest_name = len(max(sorted_timezones, key=lambda x: len(x)))
-        timezone_groups = {letter: [] for letter in ascii_lowercase}
-        for k in sorted_timezones:
-            timezone_groups[k[0]].append(k.center(biggest_name))
+        longest_name = len(max(sorted_timezones, key=lambda x: len(x)))
+        timezone_groups = defaultdict(list)
+        for tz_name in sorted_timezones:
+            timezone_groups[tz_name[0]].append(tz_name.center(longest_name))
 
         return timezone_groups
 

--- a/timezone_converter.py
+++ b/timezone_converter.py
@@ -72,8 +72,7 @@ class TimezonesComparison(Helper):
 
 class TimezonesList(Helper):
     def _sort_and_group(self):
-        pairs = [(k, v) for k, v in self.timezone_translations.items()]
-        sorted_timezones = dict(sorted([pair for pair in pairs if pair[0]]))
+        sorted_timezones = dict(sorted(self.timezone_translations.items()))
         longest_name = len(max(sorted_timezones, key=lambda x: len(x)))
         timezone_groups = defaultdict(list)
         for tz_name in sorted_timezones:


### PR DESCRIPTION
- Omit unnecessary steps to sort timezones
- Use `defaultdict` to group timezones
- Obtain `biggest_name` in a better way
- Freeze requirements