### PR TITLE
Added a command line option to output a single hour

### DIFF
--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -9,11 +9,10 @@ from timezone_converter.helper import Helper
 
 
 class ComparisonView(Helper):
-    def __init__(self, timezones: List[str], zone: bool) -> None:
-
-        hour: Union[int, None]
+    def __init__(self, timezones: List[str], zone: bool, hour: Union[int, None]) -> None:
 
         self.zone = zone
+        self.hour = hour
 
         current_dt = datetime.now()
         local_midnight = datetime(

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -46,7 +46,7 @@ class ComparisonView(Helper):
 
         return headers
 
-    def _build_table(self) -> Table:
+    def _build_table(self, single_hour) -> Table:
         headers = self._get_headers()
         table = Table()
         for header in headers:
@@ -55,7 +55,14 @@ class ComparisonView(Helper):
         fmt = '%Y-%m-%d %H:%M'
 
         current_hour = datetime.now().hour
-        for hour in range(24):
+        if single_hour is None:
+            hour_range = range(24)
+        elif single_hour == 'now':
+            hour_range = range(current_hour, current_hour + 1)
+        else:
+            hour_range = range(int(single_hour), int(single_hour) + 1)
+
+        for hour in hour_range:
             columns = [
                 (midnight + timedelta(hours=hour)).strftime(fmt)
                 for midnight in self.midnights
@@ -70,6 +77,6 @@ class ComparisonView(Helper):
 
         return table
 
-    def print_table(self) -> int:
-        self._print_with_rich(self._build_table())
+    def print_table(self, single_hour) -> int:
+        self._print_with_rich(self._build_table(single_hour))
         return 0

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -11,7 +11,10 @@ from timezone_converter.helper import Helper
 
 class ComparisonView(Helper):
     def __init__(
-        self, timezones: List[str], zone: bool, hour: Union[int, None]
+        self,
+        timezones: List[str],
+        zone: bool,
+        hour: Union[int, None],
     ) -> None:
 
         self.zone = zone

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -49,7 +49,7 @@ class ComparisonView(Helper):
 
         return headers
 
-    def _build_table(self, single_hour) -> Table:
+    def _build_table(self) -> Table:
         headers = self._get_headers()
         table = Table()
         for header in headers:
@@ -57,14 +57,11 @@ class ComparisonView(Helper):
 
         fmt = '%Y-%m-%d %H:%M'
 
-        current_hour = datetime.now().hour
-        if single_hour is None:
-            hour_range = range(24)
-        elif single_hour == 'now':
-            hour_range = range(current_hour, current_hour + 1)
-        else:
-            hour_range = range(int(single_hour), int(single_hour) + 1)
+        hour_range = range(24)
+        if self.hour is not None:
+            hour_range = range(self.hour, self.hour + 1)
 
+        current_hour = datetime.now().hour
         for hour in hour_range:
             columns = [
                 (midnight + timedelta(hours=hour)).strftime(fmt)

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from datetime import timedelta
-from typing import List, Union
+from typing import List
+from typing import Union
 
 import pytz
 from rich.table import Table
@@ -9,7 +10,9 @@ from timezone_converter.helper import Helper
 
 
 class ComparisonView(Helper):
-    def __init__(self, timezones: List[str], zone: bool, hour: Union[int, None]) -> None:
+    def __init__(
+        self, timezones: List[str], zone: bool, hour: Union[int, None]
+    ) -> None:
 
         self.zone = zone
         self.hour = hour

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
-from typing import List
+from typing import List, Union
 
 import pytz
 from rich.table import Table
@@ -10,6 +10,9 @@ from timezone_converter.helper import Helper
 
 class ComparisonView(Helper):
     def __init__(self, timezones: List[str], zone: bool) -> None:
+
+        hour: Union[int, None]
+
         self.zone = zone
 
         current_dt = datetime.now()
@@ -77,6 +80,6 @@ class ComparisonView(Helper):
 
         return table
 
-    def print_table(self, single_hour) -> int:
-        self._print_with_rich(self._build_table(single_hour))
+    def print_table(self) -> int:
+        self._print_with_rich(self._build_table())
         return 0

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -1,4 +1,5 @@
 import argparse
+from datetime import datetime
 
 from timezone_converter.comparison_view import ComparisonView
 from timezone_converter.constants import VERSION
@@ -8,8 +9,10 @@ from timezone_converter.list_view import ListView
 def _single_hour(argument: str) -> int:
     hour = int(argument)
     if hour not in range(24):
-        raise argparse.ArgumentError(None, 'Value for --single must be between
-                                     00 and 23')
+        raise argparse.ArgumentError(
+            None,
+            'Value for --single must be between 00 and 23'
+        )
     return hour
 
 def build_parser() -> argparse.ArgumentParser:
@@ -65,6 +68,7 @@ def main() -> int:
         returncode = ComparisonView(
             args.timezone,
             args.zone,
+            args.hour
         ).print_table()
     else:
         parser.print_help()

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -5,6 +5,13 @@ from timezone_converter.constants import VERSION
 from timezone_converter.list_view import ListView
 
 
+def _single_hour(argument: str) -> int:
+    hour = int(argument)
+    if hour not in range(24):
+        raise argparse.ArgumentError(None, 'Value for --single must be between
+                                     00 and 23')
+    return hour
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog='timezone-converter',
@@ -38,7 +45,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '-s',
         '--single',
-        action='store',
+        nargs='?',
+        type=_single_hour,
+        const=datetime.now().hour,
+        metavar='HOUR',
+        dest='hour',
         help='show a single hour',
     )
     return parser

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -51,7 +51,8 @@ def main() -> int:
     if args.list:
         returncode = ListView().print_columns()
     elif args.timezone:
-        returncode = ComparisonView(args.timezone, args.zone).print_table()
+        returncode = ComparisonView(args.timezone,
+                                    args.zone).print_table(args.single)
     else:
         parser.print_help()
     if returncode is None:

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -11,9 +11,10 @@ def _single_hour(argument: str) -> int:
     if hour not in range(24):
         raise argparse.ArgumentError(
             None,
-            'Value for --single must be between 00 and 23'
+            'Value for --single must be between 00 and 23',
         )
     return hour
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -68,7 +69,7 @@ def main() -> int:
         returncode = ComparisonView(
             args.timezone,
             args.zone,
-            args.hour
+            args.hour,
         ).print_table()
     else:
         parser.print_help()

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -35,6 +35,12 @@ def build_parser() -> argparse.ArgumentParser:
         action='store_true',
         help='show corresponding zone name in each column',
     )
+    parser.add_argument(
+        '-s',
+        '--single',
+        action='store',
+        help='show a single hour',
+    )
     return parser
 
 

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -51,8 +51,10 @@ def main() -> int:
     if args.list:
         returncode = ListView().print_columns()
     elif args.timezone:
-        returncode = ComparisonView(args.timezone,
-                                    args.zone).print_table(args.single)
+        returncode = ComparisonView(
+            args.timezone,
+            args.zone,
+        ).print_table(args.single)
     else:
         parser.print_help()
     if returncode is None:

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -65,7 +65,7 @@ def main() -> int:
         returncode = ComparisonView(
             args.timezone,
             args.zone,
-        ).print_table(args.single)
+        ).print_table()
     else:
         parser.print_help()
     if returncode is None:


### PR DESCRIPTION
I tried to fix #3 

I added the `-s` (`--single`) option to the command line input and enabled the programme to output a single hour.

Usage:
Output a single hour for current time.
```
$ timezone-converter hong_kong tokyo -s now
$ timezone-converter hong_kong tokyo --single now
```

Output a given hour specified by the user (e.g. 16).
```
$ timezone-converter hong_kong tokyo -s 16
$ timezone-converter hong_kong tokyo --single 16
```