### PR TITLE
Output specified letter groups in --list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = timezone_converter
-version = 0.6.1
+version = 0.7.0
 description = Compare your local timezone with foreign ones.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/timezone_converter/list_view.py
+++ b/timezone_converter/list_view.py
@@ -16,10 +16,9 @@ class ListView(Helper):
         sorted_timezones = dict(sorted(self.timezone_translations.items()))
         longest_name = len(max(sorted_timezones, key=lambda x: len(x)))
         timezone_groups: DefaultDict[str, List[str]] = defaultdict(list)
-        if self.letters:
-            for tz_name in sorted_timezones:
-                if tz_name[0] in self.letters:
-                    timezone_groups[tz_name[0]].append(tz_name.center(longest_name))
+        for tz_name in sorted_timezones:
+            if tz_name[0] in self.letters:
+                timezone_groups[tz_name[0]].append(tz_name.center(longest_name))
 
         return timezone_groups
 

--- a/timezone_converter/list_view.py
+++ b/timezone_converter/list_view.py
@@ -16,10 +16,7 @@ class ListView(Helper):
         sorted_timezones = dict(sorted(self.timezone_translations.items()))
         longest_name = len(max(sorted_timezones, key=lambda x: len(x)))
         timezone_groups: DefaultDict[str, List[str]] = defaultdict(list)
-        if self.letters == ['all']:
-            for tz_name in sorted_timezones:
-                timezone_groups[tz_name[0]].append(tz_name.center(longest_name))
-        else:
+        if self.letters is True:
             for tz_name in sorted_timezones:
                 if tz_name[0] in self.letters:
                     timezone_groups[tz_name[0]].append(tz_name.center(longest_name))

--- a/timezone_converter/list_view.py
+++ b/timezone_converter/list_view.py
@@ -9,12 +9,21 @@ from timezone_converter.helper import Helper
 
 
 class ListView(Helper):
+
+    def __init__(self, letters: List[str]) -> None:
+        self.letters = letters
+
     def _sort_and_group(self) -> DefaultDict[str, List[str]]:
         sorted_timezones = dict(sorted(self.timezone_translations.items()))
         longest_name = len(max(sorted_timezones, key=lambda x: len(x)))
         timezone_groups: DefaultDict[str, List[str]] = defaultdict(list)
-        for tz_name in sorted_timezones:
-            timezone_groups[tz_name[0]].append(tz_name.center(longest_name))
+        if self.letters == ['all']:
+            for tz_name in sorted_timezones:
+                timezone_groups[tz_name[0]].append(tz_name.center(longest_name))
+        else:
+            for tz_name in sorted_timezones:
+                if tz_name[0] in self.letters:
+                    timezone_groups[tz_name[0]].append(tz_name.center(longest_name))
 
         return timezone_groups
 

--- a/timezone_converter/list_view.py
+++ b/timezone_converter/list_view.py
@@ -9,7 +9,6 @@ from timezone_converter.helper import Helper
 
 
 class ListView(Helper):
-
     def __init__(self, letters: List[str]) -> None:
         self.letters = letters
 

--- a/timezone_converter/list_view.py
+++ b/timezone_converter/list_view.py
@@ -16,7 +16,7 @@ class ListView(Helper):
         sorted_timezones = dict(sorted(self.timezone_translations.items()))
         longest_name = len(max(sorted_timezones, key=lambda x: len(x)))
         timezone_groups: DefaultDict[str, List[str]] = defaultdict(list)
-        if self.letters is True:
+        if self.letters:
             for tz_name in sorted_timezones:
                 if tz_name[0] in self.letters:
                     timezone_groups[tz_name[0]].append(tz_name.center(longest_name))

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -1,6 +1,6 @@
 import argparse
 from datetime import datetime
-from typing import List, Union
+from typing import List
 
 from timezone_converter.comparison_view import ComparisonView
 from timezone_converter.constants import VERSION

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -30,8 +30,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '-l',
         '--list',
-        action='store_true',
-        help='show all available timezones',
+        nargs='*',
+        type=_single_letter,
+        const='all',
+        metavar='LETTER',
+        help='show all available timezones or timezones beginning with
+        specified letter groups',
     )
     parser.add_argument(
         '-V',

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -16,6 +16,7 @@ def _single_hour(argument: str) -> int:
         )
     return hour
 
+
 def _single_letter(argument: List[str]) -> List[str]:
     if argument == 'all':
         return ['all']
@@ -24,7 +25,7 @@ def _single_letter(argument: List[str]) -> List[str]:
         for letter in argument:
             if letter.isalpha() is False:
                 raise argparse.ArgumentError(
-                    'Value for --list must be single letters or None'
+                    'Value for --list must be single letters or None',
                 )
         return argument
 

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -1,5 +1,6 @@
 import argparse
 from datetime import datetime
+from typing import List, Union
 
 from timezone_converter.comparison_view import ComparisonView
 from timezone_converter.constants import VERSION
@@ -14,6 +15,18 @@ def _single_hour(argument: str) -> int:
             'Value for --single must be between 00 and 23',
         )
     return hour
+
+def _single_letter(argument: List[str]) -> List[str]:
+    if argument == 'all':
+        return ['all']
+    else:
+        argument = list(argument)
+        for letter in argument:
+            if letter.isalpha() is False:
+                raise argparse.ArgumentError(
+                    'Value for --list must be single letters or None'
+                )
+        return argument
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -30,12 +43,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '-l',
         '--list',
-        nargs='*',
+        nargs='?',
         type=_single_letter,
         const='all',
         metavar='LETTER',
-        help='show all available timezones or timezones beginning with
-        specified letter groups',
+        help='show all available timezones or timezones beginning with specified letter groups',
     )
     parser.add_argument(
         '-V',
@@ -68,7 +80,7 @@ def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
     if args.list:
-        returncode = ListView().print_columns()
+        returncode = ListView(args.list).print_columns()
     elif args.timezone:
         returncode = ComparisonView(
             args.timezone,

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -17,17 +17,14 @@ def _single_hour(argument: str) -> int:
     return hour
 
 
-def _single_letter(argument: List[str]) -> List[str]:
-    if argument == 'all':
-        return ['all']
-    else:
-        argument = list(argument)
-        for letter in argument:
-            if letter.isalpha() is False:
-                raise argparse.ArgumentError(
-                    'Value for --list must be single letters or None',
-                )
-        return argument
+def _list_letter(argument: str) -> List[str]:
+    argument_set = set(argument)
+    if any(not arg.isalpha() for arg in argument_set):
+        raise argparse.ArgumentError(
+            None,
+            'Values for --list cannot contain numbers',
+        )
+    return sorted(argument_set)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -43,7 +43,7 @@ def build_parser() -> argparse.ArgumentParser:
         '-l',
         '--list',
         nargs='?',
-        type=_single_letter,
+        type=_list_letter,
         const=list(string.ascii_lowercase),
         metavar='LETTER',
         help='show all timezones or only those that start with specific letters',

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -1,5 +1,6 @@
 import argparse
 from datetime import datetime
+import string
 from typing import List
 
 from timezone_converter.comparison_view import ComparisonView
@@ -43,9 +44,9 @@ def build_parser() -> argparse.ArgumentParser:
         '--list',
         nargs='?',
         type=_single_letter,
-        const='all',
+        const=list(string.ascii_lowercase),
         metavar='LETTER',
-        help='show all available timezones or timezones beginning with specified letter groups',
+        help='show all timezones or only those that start with specific letters',
     )
     parser.add_argument(
         '-V',


### PR DESCRIPTION
Trying to fix #19 

Usage:
```shell
# List all letter groups
$ timezone-converter --list
# List timezones beginning with 'm'
$ timezone-converter --list m
# List timezones beginning with 'b', 'd', or 't'
$ timezone-converter --list bdt
```