### PR TITLE
Harden release publishing workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,53 +3,84 @@ name: deployment
 on:
   release:
     types:
-      - created
+      - published
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
-      - name: Install pypa/build
-        run: python -m pip install --upgrade pip build
+      - name: Validate release version
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import tomllib
+
+          tag = os.environ['GITHUB_REF_NAME']
+          with open('pyproject.toml', 'rb') as config:
+              version = tomllib.load(config)['project']['version']
+
+          if tag != f'v{version}' and tag != version:
+              print(
+                  f'Release tag {tag!r} does not match '
+                  f'pyproject.toml version {version!r}.',
+              )
+              sys.exit(1)
+          PY
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip build -e . -r requirements-dev.txt
+
+      - name: Run tests
+        run: coverage run -m pytest && coverage report
 
       - name: Build a binary wheel and a source tarball
         run: python -m build --sdist --wheel --outdir=dist/ .
 
-      - name: Publish distribution 📦
+      - name: Publish distribution
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: bledy/timezone-converter
-          tags: type=semver,pattern={{version}}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
 
       - name: Login to Docker Hub
         id: login-dockerhub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,55 @@
+# Release checklist
+
+This project uses a static package version in `pyproject.toml`. Release tags
+must match that version exactly, either as `X.Y.Z` or `vX.Y.Z`.
+
+## Before creating the release
+
+- Update `project.version` in `pyproject.toml`.
+- Update user-facing docs when behavior or CLI flags changed.
+- When adding a CLI flag, add a smoke-test invocation to the tox `commands`
+  list in `pyproject.toml`.
+- Run `pre-commit run --all-files`.
+- Run `coverage run -m pytest && coverage report`.
+- Run any Docker command you want to verify locally, for example
+  `docker build -t timezone-converter:local .`.
+
+## Create the release
+
+- Commit the release changes.
+- Tag the commit with the matching version, for example `v0.15.0`.
+- Create and publish a GitHub Release from that tag.
+
+## Automated publishing
+
+Publishing the GitHub Release triggers `.github/workflows/deployment.yml`.
+That workflow:
+
+- validates the release tag against `pyproject.toml`;
+- targets the `release` GitHub Actions environment;
+- runs the test suite;
+- builds the wheel and source distribution;
+- publishes to PyPI with trusted publishing;
+- builds and pushes Docker images for `linux/amd64` and `linux/arm64`.
+
+Docker Hub receives these tags for non-prerelease semver releases:
+
+- exact version, for example `0.15.0`;
+- minor version, for example `0.15`;
+- `latest`.
+
+Prereleases do not update `latest`.
+
+## PyPI trusted publishing
+
+The workflow does not use a `PYPI_API_TOKEN`. Configure this repository as a
+trusted publisher for the `timezone-converter` project in PyPI, with:
+
+- owner: `ibLeDy`;
+- repository: `timezone-converter`;
+- workflow: `deployment.yml`;
+- environment: `release`.
+
+Also create a `release` environment in the repository's GitHub Actions settings.
+Use environment protection rules there if PyPI publishing should require manual
+approval or be restricted to specific maintainers.


### PR DESCRIPTION
## Summary
- publish only when GitHub releases are published
- validate release tags against the static pyproject version before publishing
- run tests before publishing, use PyPI trusted publishing, and update GitHub/Docker actions
- bind publishing to the `release` GitHub Actions environment for PyPI trusted publishing
- add multi-arch Docker publishing tags and document the static-version release checklist

## Tests
- pre-commit run --all-files
- python3 -m pytest