### PR TITLE
Prepare release v0.15.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "timezone-converter"
-version = "0.15.0"
+version = "0.15.1"
 description = "Compare your local timezone with foreign ones."
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary
- bump the static package version from 0.15.0 to 0.15.1
- verify the release workflow tag check accepts v0.15.1

## Release notes
After this PR merges, create and publish a GitHub Release for tag `v0.15.1`. The deployment workflow will validate the tag against `pyproject.toml`, publish to PyPI through trusted publishing, and push Docker tags `0.15.1`, `0.15`, and `latest`.

## Tests
- pre-commit run --all-files
- python3 -m pytest
- GITHUB_REF_NAME=v0.15.1 release version validation snippet