### PR TITLE
Bump version to 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "timezone-converter"
-version = "0.15.1"
+version = "0.16.0"
 description = "Compare your local timezone with foreign ones."
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary
- bump package version from 0.15.1 to 0.16.0 after the dependency modernization

## Verification
- python3 -m pytest
- pre-commit run --files pyproject.toml
- python -m timezone_converter.main --version