### PR TITLE
Bump version to 0.16.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "timezone-converter"
-version = "0.16.0"
+version = "0.16.1"
 description = "Compare your local timezone with foreign ones."
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Patch release following [#63](https://github.com/ibLeDy/timezone-converter/pull/63).

## Changes since 0.16.0
- **Fix:** the comparison table now spans the real local day (23/24/25 hours) across DST transitions instead of a hard-coded 24 rows — previously a spring-forward day spilled a row into the next day and a fall-back day dropped `23:00`.
- Minor: removed a redundant empty-list guard in `SearchView`.

Version-only change to `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)