### PR TITLE
Disable pre-commit.ci autofix PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: true
+  autofix_prs: false
   autoupdate_schedule: monthly
 
 repos:


### PR DESCRIPTION
Replaces #55 (which was mislabeled — it removed the whole `ci:` block, reverting to defaults where `autofix_prs` is **true** and `autoupdate_schedule` is **weekly**, i.e. the opposite of its stated intent).

This sets `autofix_prs: false` so pre-commit.ci stops pushing auto-fix commits onto PR branches, while keeping `autoupdate_schedule: monthly` so hook versions are still bumped on a low-noise cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)