### PR TITLE
Update pre-commit hooks to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -40,25 +40,23 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.14.0
+    rev: v3.16.0
     hooks:
       - id: reorder-python-imports
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.1.0
+    rev: v4.0.0
     hooks:
       - id: add-trailing-comma
-        args:
-          - "--py36-plus"
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: v1.5.6
     hooks:
       - id: remove-crlf
       - id: remove-tabs
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.7.0
+    rev: v3.2.0
     hooks:
       - id: setup-cfg-fmt
         args:
@@ -75,14 +73,14 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.5.1
     hooks:
       - id: black
         args:
           - "--skip-string-normalization"
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         args:
@@ -94,6 +92,6 @@ repos:
       - id: yesqa
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v2.1.0
     hooks:
       - id: mypy

--- a/timezone_converter/helper.py
+++ b/timezone_converter/helper.py
@@ -9,7 +9,6 @@ from rich.columns import Columns
 from rich.console import Console
 from rich.table import Table
 
-
 _ALL_TIMEZONES = sorted(available_timezones())
 _TIMEZONE_TRANSLATIONS: Dict[str, str] = {
     tz.lower().split('/')[-1]: tz for tz in _ALL_TIMEZONES


### PR DESCRIPTION
Freshly regenerated `pre-commit autoupdate`, replacing the ~9-month-stale #56 (whose pins were behind and whose major bumps were never CI-verified).

## Hook bumps
| hook | from | to |
|---|---|---|
| pre-commit-hooks | v5.0.0 | v6.0.0 |
| reorder-python-imports | v3.14.0 | v3.16.0 |
| add-trailing-comma | v3.1.0 | v4.0.0 |
| Lucas-C/pre-commit-hooks | v1.5.5 | v1.5.6 |
| setup-cfg-fmt | v2.7.0 | v3.2.0 |
| black | 24.10.0 | 26.5.1 |
| flake8 | 7.1.1 | 7.3.0 |
| mypy | v1.14.1 | v2.1.0 |

## Fallout addressed
- **add-trailing-comma v4** removed the `--py36-plus` flag (now unrecognized) — dropped it from `args`.
- **black 26** reformatted one blank line in `helper.py`.

## Verification
- `pre-commit run --all-files` clean (incl. mypy 2.x strict, flake8, black 26).
- `pytest`: 43 passing, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)