### PR TITLE
Add tzconv as a short alias for timezone-converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ pip install -U timezone-converter
 timezone-converter <timezone> [<timezone> ...]
 ```
 
+The short alias `tzconv` also works, if you prefer less typing.
+
 Useful flags:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 
 [project.scripts]
 timezone-converter = "timezone_converter.main:main"
+tzconv = "timezone_converter.main:main"
 
 [project.urls]
 Homepage = "https://github.com/ibLeDy/timezone-converter"
@@ -113,4 +114,5 @@ commands =
     timezone-converter --search york
     timezone-converter --list
     timezone-converter --list tbd
+    tzconv --version
 """


### PR DESCRIPTION
## Summary

- Adds `tzconv` as a **second** `console_scripts` entry point in `pyproject.toml`, pointing at the same `timezone_converter.main:main` function used by the existing `timezone-converter` command.
- Notes the alias in the README next to the existing usage instructions.
- Adds `tzconv --version` to the tox smoke-test commands so both entry points are exercised in CI.

## Why `tzconv`

Closes #22, which asked for a shorter command name. In the original 2021 discussion the maintainer leaned toward users creating their own shell alias (e.g. `alias tz-conv="timezone-converter"`), but conceded a second built-in entry point "wouldn't hurt" — calling naming "the tough part". Candidates considered for that name:

- **`tz`** — rejected. Collides with the existing [`tz` world-clock/timezone CLI](https://github.com/oz/tz) that many developers already have installed, and a bare two-letter name is generic enough to shadow other tools.
- **`tzc`** — rejected. Too terse; not obvious at a glance what it does.
- **`tz-conv`** — the issue's own literal suggestion. Viable, but hyphenated names are less idiomatic for short global CLI commands.
- **`tzconv`** (chosen) — compact, unhyphenated, reads clearly as derived from "timezone-converter", and no widely-used existing tool appears to claim this exact name.

Went with `tzconv`. If the maintainer prefers matching the issue's literal wording, switching to `tz-conv` is a one-line diff (just the entry-point name in `pyproject.toml` plus the README mention and tox smoke command).

## Non-breaking

This is purely additive: `timezone-converter` remains the primary, unchanged command referenced everywhere (README, PyPI listing, existing installs). `tzconv` is only a second entry point pointing at the same `main()`. Nothing is renamed or removed, consistent with the maintainer's stated preference against a breaking rename.

## Test plan

- [x] `pip install -e . -r requirements-dev.txt` and confirmed both `which tzconv` and `tzconv --version` work locally alongside `timezone-converter --version`.
- [x] `coverage run -m pytest && coverage report` — 100% coverage maintained (this is a packaging-metadata change, no Python source touched).
- [x] `pre-commit run --all-files` — all hooks pass.

Closes #22


---
_Generated by [Claude Code](https://claude.ai/code/session_016P9JaM9WNHwpoL3RrT99ie)_