### PR TITLE
Show installed tzdata version in --version output

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 
 import pytest
 
@@ -40,6 +41,13 @@ def test_build_parser_defaults():
 def test_build_parser_normalizes_search():
     args = build_parser().parse_args(['--search', 'York'])
     assert args.search == 'york'
+
+
+def test_build_parser_version_includes_tzdata_version(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(['--version'])
+    output = capsys.readouterr().out
+    assert re.search(r'tzdata \d', output)
 
 
 def _patch_view(monkeypatch, name, method, returns=0):

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib.metadata
 import string
 from datetime import datetime
 from typing import List
@@ -50,11 +51,12 @@ def build_parser() -> argparse.ArgumentParser:
         metavar='LETTER',
         help='show all timezones or only those that start with specific letters',
     )
+    tzdata_version = importlib.metadata.version('tzdata')
     parser.add_argument(
         '-V',
         '--version',
         action='version',
-        version=f'%(prog)s {VERSION}',
+        version=f'%(prog)s {VERSION} (tzdata {tzdata_version})',
         help='show program\'s version number and exit',
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

- Extend the existing `-V`/`--version` output to also show the installed `tzdata` package version, e.g. `timezone-converter 0.16.1 (tzdata 2026.3)`.
- Uses `importlib.metadata.version('tzdata')` (stdlib since Python 3.8) at parser-build time in `build_parser()`.
- No new flag was added: extending `--version` is more discoverable than a separate flag and avoids flag proliferation.
- No defensive `try`/`except` was added around the `tzdata` lookup, since `tzdata` is a hard runtime dependency (already declared in `pyproject.toml`'s `dependencies` and required for `zoneinfo` to work correctly per this repo's `AGENTS.md`).

**Scope note on the issue title:** the issue title says "pytz", but this project does not use pytz — per `AGENTS.md`, "Timezone data comes from `zoneinfo` plus `tzdata`; avoid platform-specific behavior." The title appears to be stale/mistaken, so this PR implements the request against the actual dependency (`tzdata`) rather than pytz.

## Test plan

- [x] Added `test_build_parser_version_includes_tzdata_version` in `tests/main_test.py`, asserting the `--version` output contains `tzdata ` followed by a digit (not hardcoding the exact tzdata version, since it will drift over time).
- [x] `coverage run -m pytest && coverage report` — 100% coverage, all 44 tests pass.
- [x] `pre-commit run --all-files` — all hooks pass, including strict MyPy.
- [x] Manually ran `timezone-converter --version` locally and confirmed output: `timezone-converter 0.16.1 (tzdata 2026.3)`.
- [x] Checked README.md for any documented example `--version` output to update — none exists, so no README changes were needed.

Closes #57


---
_Generated by [Claude Code](https://claude.ai/code/session_016P9JaM9WNHwpoL3RrT99ie)_