### PR TITLE
Rename --single/-s to --hour/-H for single-hour output

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Useful flags:
 ```bash
 timezone-converter tijuana new_york --zone
 timezone-converter tijuana new_york --order
-timezone-converter tijuana --single 14
+timezone-converter tijuana --hour 14
 timezone-converter --search york
 timezone-converter --list tbd
 ```
@@ -100,7 +100,7 @@ difference from your local timezone.
 
 ### Output a single hour
 
-Using the `--single` argument, you can output a single hour. If you don't
+Using the `--hour` argument, you can output a single hour. If you don't
 provide a value, the current hour will be displayed.
 
 ### Search for a timezone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,10 +104,10 @@ commands =
     timezone-converter
     timezone-converter --help
     timezone-converter tijuana
-    timezone-converter tijuana --single
-    timezone-converter tijuana --single 14
+    timezone-converter tijuana --hour
+    timezone-converter tijuana --hour 14
     timezone-converter tijuana new_york
-    timezone-converter tijuana new_york --single
+    timezone-converter tijuana new_york --hour
     timezone-converter tijuana --zone
     timezone-converter tijuana new_york --order
     timezone-converter --search york

--- a/tests/comparison_view_test.py
+++ b/tests/comparison_view_test.py
@@ -166,7 +166,7 @@ def test_headers_with_zone_include_abbreviation():
     assert headers[1] == 'AMERICA/NEW_YORK (EST)'
 
 
-def test_single_hour_builds_one_row():
+def test_hour_builds_one_row():
     view = _make_view(['new_york'], hour=9)
     assert len(view._build_table().rows) == 1
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -3,20 +3,20 @@ import argparse
 import pytest
 
 from timezone_converter import main as main_module
+from timezone_converter.main import _hour_value
 from timezone_converter.main import _list_letter
-from timezone_converter.main import _single_hour
 from timezone_converter.main import build_parser
 from timezone_converter.main import main
 
 
-def test_single_hour_valid():
-    assert _single_hour('0') == 0
-    assert _single_hour('23') == 23
+def test_hour_value_valid():
+    assert _hour_value('0') == 0
+    assert _hour_value('23') == 23
 
 
-def test_single_hour_invalid():
+def test_hour_value_invalid():
     with pytest.raises(argparse.ArgumentError):
-        _single_hour('24')
+        _hour_value('24')
 
 
 def test_list_letter_normalizes():

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -10,12 +10,12 @@ from timezone_converter.list_view import ListView
 from timezone_converter.search_view import SearchView
 
 
-def _single_hour(argument: str) -> int:
+def _hour_value(argument: str) -> int:
     hour = int(argument)
     if hour not in range(24):
         raise argparse.ArgumentError(
             None,
-            'Value for --single must be between 00 and 23',
+            'Value for --hour must be between 00 and 23',
         )
     return hour
 
@@ -64,10 +64,10 @@ def build_parser() -> argparse.ArgumentParser:
         help='show corresponding zone name in each column',
     )
     parser.add_argument(
-        '-s',
-        '--single',
+        '-H',
+        '--hour',
         nargs='?',
-        type=_single_hour,
+        type=_hour_value,
         const=datetime.now().hour,
         metavar='HOUR',
         dest='hour',


### PR DESCRIPTION
## Summary

- Renames the single-hour-output flag from `-s`/`--single` to `-H`/`--hour`.
- `-s`/`--single` only existed to dodge a collision with `-h`/`--help`; once renamed, `-s` had no mnemonic connection to "hour" left, so it wasn't reused.
- `--hour` was chosen because it already matches the existing `dest='hour'`/`metavar='HOUR'`, making it the least-surprising name. The concern that `--hour` might read as requiring a value is addressed by argparse's own generated usage string, which already shows it as optional via `[HOUR]`.
- `-H` (uppercase) was chosen as the short flag: it's mnemonic for "Hour", doesn't collide with `-h` (reserved for `--help`), and isn't used by any other current flag (`-l/--list`, `-V/--version`, `-z/--zone`, `-S/--search`, `-o/--order`).
- The internal helper `_single_hour` was renamed to `_hour_value` to match, and its error message now reads `Value for --hour must be between 00 and 23`.

## Breaking change

**This drops `-s`/`--single` entirely — no deprecated alias or compatibility shim is kept.** The project has no `v1.0.0` release yet (see the pending `v1.0.0` milestone), so this is treated as a pre-1.0 breaking rename rather than something that needs a deprecation period. Carrying a hidden alias for a flag that only ever existed as a stopgap name felt like unnecessary long-term baggage for a project that hasn't cut a stable release. If you'd rather ship this with a deprecation window (e.g. keep `-s`/`--single` working with a warning for one release), happy to add that instead — just let me know.

## Changes

- `timezone_converter/main.py`: parser flag `-H`/`--hour`, renamed `_single_hour` → `_hour_value`, updated error message.
- `README.md`: usage example and "Output a single hour" section updated to `--hour`.
- `pyproject.toml`: tox smoke-test commands updated to use `--hour`.
- `tests/main_test.py`, `tests/comparison_view_test.py`: updated flag/helper references and renamed test functions.

## Test plan

- [x] `coverage run -m pytest && coverage report` — 43 passed, 100% coverage
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Manually verified `--hour`/`-H` work and `--single`/`-s` are rejected as unrecognized arguments
- [x] Manually verified the out-of-range error message reads `Value for --hour must be between 00 and 23`
- [x] `grep -rn "single\|-s" .` (excluding `.git`) shows no leftover flag references — only the unrelated English phrase "single hour" in help/README prose

Closes #36


---
_Generated by [Claude Code](https://claude.ai/code/session_016P9JaM9WNHwpoL3RrT99ie)_