### PR TITLE
test: add DST, boundary, and lookup edge-case regressions

### DIFF
--- a/tests/comparison_view_test.py
+++ b/tests/comparison_view_test.py
@@ -179,3 +179,106 @@ def test_current_hour_row_is_highlighted():
 
 def test_print_table_returns_zero():
     assert _make_view(['new_york'], hour=9).print_table() == 0
+
+
+def test_local_day_is_complete_when_southern_hemisphere_clocks_fall_back(
+    local_timezone,
+):
+    # Regression: every fall-back test so far used a Northern Hemisphere zone
+    # that falls back in November. Australia/Sydney falls back in April; the
+    # local day must still expand to 25 hours with the repeated hour shown,
+    # proving the table isn't built around a hemisphere-specific calendar
+    # assumption.
+    zone = local_timezone('Australia/Sydney')
+    cells = _local_column((2026, 4, 5), zone)  # DST ends 03:00 -> 02:00
+    assert len(cells) == 25
+    assert cells[0] == '2026-04-05 00:00'
+    assert cells[-1] == '2026-04-05 23:00'
+    assert cells.count('2026-04-05 02:00') == 2  # repeated hour is shown
+    assert all(cell.startswith('2026-04-05') for cell in cells)
+
+
+def test_local_day_does_not_spill_for_southern_hemisphere_spring_forward(
+    local_timezone,
+):
+    # Regression companion: Sydney springs forward in October, not March; the
+    # local day must shrink to 23 hours with the skipped hour absent.
+    zone = local_timezone('Australia/Sydney')
+    cells = _local_column((2026, 10, 4), zone)  # DST starts 02:00 -> 03:00
+    assert len(cells) == 23
+    assert cells[0] == '2026-10-04 00:00'
+    assert cells[-1] == '2026-10-04 23:00'
+    assert '2026-10-04 02:00' not in cells
+    assert all(cell.startswith('2026-10-04') for cell in cells)
+
+
+def test_half_hour_dst_offset_still_yields_a_25_hour_fall_back_day(
+    local_timezone,
+):
+    # Regression: every other DST test shifts by a full hour. Australia/
+    # Lord_Howe shifts by only 30 minutes, so code that compares
+    # ``strftime('%H:%M')`` strings for an exact repeated hour (rather than
+    # walking real UTC instants) would silently mishandle it. The day is
+    # still 25 real hours long even though no single local clock time
+    # literally repeats.
+    zone = local_timezone('Australia/Lord_Howe')
+    cells = _local_column((2026, 4, 5), zone)  # offset: +11:00 -> +10:30
+    assert len(cells) == 25
+    assert cells[0] == '2026-04-05 00:00'
+    assert cells[-1] == '2026-04-05 23:30'
+    assert all(cell.startswith('2026-04-05') for cell in cells)
+
+
+def test_half_hour_dst_offset_still_yields_a_24_row_spring_forward_day(
+    local_timezone,
+):
+    # Regression companion: Lord Howe's spring-forward loses only 30 minutes,
+    # not a full hour, so the row count stays 24 instead of dropping to 23
+    # the way a full-hour spring-forward zone does. A naive "spring forward
+    # always means 23 rows" assumption would fail this.
+    zone = local_timezone('Australia/Lord_Howe')
+    cells = _local_column((2026, 10, 4), zone)  # offset: +10:30 -> +11:00
+    assert len(cells) == 24
+    assert cells[0] == '2026-10-04 00:00'
+    assert cells[-1] == '2026-10-04 23:30'
+    assert '2026-10-04 02:00' not in cells
+    assert all(cell.startswith('2026-10-04') for cell in cells)
+
+
+def test_hour_zero_produces_single_row_not_full_day():
+    # Boundary regression: hour=0 is falsy in Python, so a bug that checks
+    # ``if self.hour:`` instead of ``if self.hour is not None:`` would
+    # silently render the full day table instead of the single midnight row.
+    # Combined with --zone to also confirm the abbreviation header still
+    # reflects the base instant's DST state at the boundary.
+    view = _make_view(['new_york'], hour=0, zone=True)
+    view.base_instant = datetime(2026, 6, 1, tzinfo=ZoneInfo('America/New_York'))
+    table = view._build_table()
+    assert len(table.rows) == 1
+    assert list(table.columns[1]._cells) == ['2026-06-01 00:00']
+    assert view._get_headers()[1] == 'AMERICA/NEW_YORK (EDT)'
+
+
+def test_hour_twenty_three_respects_order_sorted_zones(local_timezone):
+    # Boundary regression: --single 23 is the high edge of the 00-23 range.
+    # Combined with --order, the single row must be built from the zones
+    # list already sorted by offset distance in __init__, not the original
+    # argument order.
+    local_timezone('Pacific/Kwajalein')  # pins local offset to UTC+12
+    view = _make_view(['calcutta', 'gmt+12'], hour=23, order=True)
+    view.base_instant = datetime(2026, 1, 15, tzinfo=datetime_timezone.utc)
+    # Asia/Calcutta (+05:30) is closer to +12:00 local than Etc/GMT+12
+    # (-12:00), so order must place it first.
+    assert view._get_headers()[1:] == ['ASIA/CALCUTTA', 'ETC/GMT+12']
+    table = view._build_table()
+    assert len(table.rows) == 1
+    assert len(table.columns) == 3
+
+
+def test_ambiguous_short_name_resolves_via_comparison_view():
+    # Regression: "istanbul" is ambiguous between Asia/Istanbul and
+    # Europe/Istanbul (helper_test.py covers resolve_timezone directly); this
+    # exercises the same resolution through the actual CLI construction path
+    # so a real, resolvable IANA zone always comes out the other end.
+    view = _make_view(['istanbul'])
+    assert str(view.zones[1]) in ('Asia/Istanbul', 'Europe/Istanbul')

--- a/tests/list_view_test.py
+++ b/tests/list_view_test.py
@@ -19,3 +19,13 @@ def test_list_includes_ambiguous_canonical_paths(capsys):
 def test_list_all_letters(capsys):
     ListView(list(string.ascii_lowercase)).print_columns()
     assert 'utc' in capsys.readouterr().out
+
+
+def test_list_letter_with_no_matches_prints_without_error(capsys):
+    # Edge case: no available timezone name starts with "x", so the filtered
+    # group is empty. This must render cleanly (no panel, no crash) rather
+    # than assuming every requested letter has at least one match.
+    code = ListView(['x']).print_columns()
+    out = capsys.readouterr().out
+    assert code == 0
+    assert 'amsterdam' not in out

--- a/tests/search_view_test.py
+++ b/tests/search_view_test.py
@@ -35,3 +35,23 @@ def test_search_includes_unambiguous_canonical_paths(capsys):
 def test_search_no_results(capsys):
     SearchView('zzzzzzzzzz').print_search_results()
     assert 'Found 0 timezones' in capsys.readouterr().out
+
+
+def test_search_empty_string_finds_nothing(capsys):
+    # Edge case: an empty search term (e.g. `--search ''`) must degrade
+    # gracefully to zero matches instead of matching everything or raising.
+    code = SearchView('').print_search_results()
+    out = capsys.readouterr().out
+    assert code == 0
+    assert 'Found 0 timezones' in out
+
+
+def test_search_single_character_finds_nothing(capsys):
+    # Edge case: difflib's default similarity cutoff can't be cleared by a
+    # single character against multi-character zone names, so a one-letter
+    # filter (distinct from --list's single-letter grouping) should report
+    # zero fuzzy matches rather than an arbitrary subset.
+    code = SearchView('a').print_search_results()
+    out = capsys.readouterr().out
+    assert code == 0
+    assert 'Found 0 timezones' in out


### PR DESCRIPTION
## Summary

The suite already has 43 tests and 100% line+branch coverage, but 100% coverage only proves every statement/branch *executes* — not that every DST/argument edge case is exercised. This adds ten targeted regression tests, matching the existing `local_timezone`/`_to_local` monkeypatch pattern used in `tests/comparison_view_test.py`:

- **Southern Hemisphere DST** (`Australia/Sydney`): fall-back in April (25-hour day, repeated `02:00`) and spring-forward in October (23-hour day, skipped `02:00`) — every existing DST test only covers a Northern Hemisphere zone that transitions in March/November.
- **Half-hour DST offset** (`Australia/Lord_Howe`): its DST shift is 30 minutes, not a full hour. Fall-back still yields 25 rows and spring-forward yields **24** rows (not 23), since only half an hour is lost. This guards against code that assumes DST always shifts by a whole hour.
- **`--hour`/`--single` boundaries**: `hour=0` combined with `--zone` (guards against a `if self.hour:` truthiness bug swallowing the falsy `0`), and `hour=23` combined with `--order` (confirms the single-row table is built from the already-sorted zone list).
- **Ambiguous short-name resolution** (`istanbul`) exercised through the actual `ComparisonView` construction path, not just `Helper.resolve_timezone` in isolation.
- **`--search` edge cases**: empty string and a single character both degrade to zero fuzzy matches instead of matching everything.
- **`--list` edge case**: a letter with no matching timezone (`x`) renders cleanly with no panel and no crash.

Each new test has a comment explaining the specific regression it guards against.

## Test plan

- [x] `coverage run -m pytest && coverage report` — 53 passed, 100% line+branch coverage maintained
- [x] `pre-commit run --all-files` — all hooks pass, including strict MyPy

Closes #74


---
_Generated by [Claude Code](https://claude.ai/code/session_016P9JaM9WNHwpoL3RrT99ie)_