### PR TITLE
Center columns using the widest header across the row

### DIFF
--- a/tests/comparison_view_test.py
+++ b/tests/comparison_view_test.py
@@ -4,6 +4,7 @@ from datetime import timezone as datetime_timezone
 from zoneinfo import ZoneInfo
 
 import pytest
+from rich.console import Console
 
 import timezone_converter.comparison_view as comparison_view
 from timezone_converter.comparison_view import ComparisonView
@@ -164,6 +165,54 @@ def test_headers_with_zone_include_abbreviation():
     headers = view._get_headers()
     assert headers[0].startswith('LOCAL (')
     assert headers[1] == 'AMERICA/NEW_YORK (EST)'
+
+
+def test_columns_share_widest_header_width():
+    # Regression: Rich sizes each column from its own content, so a short
+    # header (e.g. "UTC") next to a long one (e.g. an exact IANA path) used
+    # to render as a narrow column beside a wide one. Every column should
+    # instead be floored to the widest header across the whole row.
+    view = _make_view(['utc', 'america/argentina/buenos_aires'])
+    view.zones = [
+        None,
+        ZoneInfo('UTC'),
+        ZoneInfo('America/Argentina/Buenos_Aires'),
+    ]
+    headers = view._get_headers()
+    widest = max(len(header) for header in headers)
+    assert widest > len('LOCAL')  # sanity: headers really do differ in length
+
+    table = view._build_table()
+    assert [column.min_width for column in table.columns] == [widest] * len(
+        headers,
+    )
+
+    console = Console(width=200)
+    rendered_widths = table._calculate_column_widths(console, console.options)
+    assert len(set(rendered_widths)) == 1
+
+
+def test_columns_share_widest_header_width_with_zone_abbreviations():
+    # Same guarantee with --zone, whose abbreviation suffix (e.g. "(-03)")
+    # makes header lengths diverge even further between columns.
+    view = _make_view(['utc', 'america/argentina/buenos_aires'], zone=True)
+    view.base_instant = datetime(2026, 7, 20, tzinfo=datetime_timezone.utc)
+    view.zones = [
+        None,
+        ZoneInfo('UTC'),
+        ZoneInfo('America/Argentina/Buenos_Aires'),
+    ]
+    headers = view._get_headers()
+    widest = max(len(header) for header in headers)
+
+    table = view._build_table()
+    assert [column.min_width for column in table.columns] == [widest] * len(
+        headers,
+    )
+
+    console = Console(width=200)
+    rendered_widths = table._calculate_column_widths(console, console.options)
+    assert len(set(rendered_widths)) == 1
 
 
 def test_single_hour_builds_one_row():

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -116,9 +116,18 @@ class ComparisonView(Helper):
 
     def _build_table(self) -> Table:
         headers = self._get_headers()
+        # Size every column to the widest header across the whole row, not
+        # just its own content. Rich otherwise auto-sizes each column
+        # independently, so a long ``--zone`` header (e.g.
+        # ``AMERICA/NEW_YORK (EST)``) next to a short one (e.g. ``UTC (UTC)``)
+        # makes the row look inconsistently sized even though each column is
+        # centered relative to itself. ``min_width`` only sets a floor, so
+        # narrower columns grow to match without truncating wider ones or
+        # changing narrow-terminal wrapping behavior.
+        widest_header = max((len(header) for header in headers), default=0)
         table = Table()
         for header in headers:
-            table.add_column(header, justify='center')
+            table.add_column(header, justify='center', min_width=widest_header)
 
         if self.hour is not None:
             base_utc = self.base_instant.astimezone(datetime_timezone.utc)


### PR DESCRIPTION
## Interpretation of #49

The issue body is empty — only the title, "Center text using the widest name amongst all requested timezones". I interpreted this as: today, Rich's `Table.add_column()` auto-sizes each column independently based on that column's own content (its header vs. its fixed-width `%Y-%m-%d %H:%M` rows). With `--zone`, headers vary a lot in length across columns (e.g. `AMERICA/NEW_YORK (EST)` vs `UTC (UTC)`), and exact IANA paths can be long too (e.g. `AMERICA/ARGENTINA/BUENOS_AIRES`). Each column's content is still centered *within itself*, but because column widths differ, the row as a whole reads as visually inconsistent — like a ragged grid rather than a uniform table.

**Fix:** in `ComparisonView._build_table()`, compute `widest_header = max(len(h) for h in headers)` once headers are built, then pass it as `min_width=widest_header` to every `table.add_column(...)` call. `min_width` only sets a floor (verified against the installed `rich==15.0.0` `Table.add_column`/`Column` signature), so:
- Every column renders at the same width — the widest header in the row.
- Content stays centered (`justify='center'`) within that shared width.
- No column is truncated (the floor is the max, so nothing needs to shrink).
- Narrow-terminal wrapping/ellipsis behavior for individual cells is unaffected — this only changes the floor, not `width`/`max_width`.

`_get_headers()` itself is untouched; only how `_build_table()` sizes columns changed. No conversion/DST/highlighting/ordering logic was touched.

## Before / after (manually exercised, not just unit tests)

Ran `timezone-converter utc america/argentina/buenos_aires --single 9` (short header next to a long exact IANA path) before and after the change, `COLUMNS=200`:

**Before** — narrow columns (`LOCAL`, `UTC`) next to one much wider column:
```
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃      LOCAL       ┃       UTC        ┃ AMERICA/ARGENTINA/BUENOS_AIRES ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 2026-07-20 09:00 │ 2026-07-20 09:00 │        2026-07-20 06:00        │
└──────────────────┴──────────────────┴────────────────────────────────┘
```

**After** — all three columns share the widest column's width:
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃             LOCAL              ┃              UTC               ┃ AMERICA/ARGENTINA/BUENOS_AIRES ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│        2026-07-20 09:00        │        2026-07-20 09:00        │        2026-07-20 06:00        │
└────────────────────────────────┴────────────────────────────────┴────────────────────────────────┘
```

Same comparison with `--zone` added (abbreviation suffixes make lengths diverge even more) shows the same before/after pattern — confirmed locally.

**Note:** `.github/assets/tijuana_zone.svg` and `.github/assets/tijuana_new_york.svg` (referenced from `README.md`) render comparisons that could shift width under this change and may now be stale. I can't regenerate these SVGs myself in this environment — flagging for the maintainer to refresh if the rendered widths visibly changed.

## Test plan

- Added `test_columns_share_widest_header_width` and `test_columns_share_widest_header_width_with_zone_abbreviations` to `tests/comparison_view_test.py`, mixing a short header (`UTC`) with a long exact IANA path (`America/Argentina/Buenos_Aires`), with and without `--zone`. Each asserts:
  - every `Column.min_width` equals the row's widest header length,
  - Rich's actual computed render widths (`Table._calculate_column_widths`) are identical across all columns.
- `coverage run -m pytest && coverage report` → 45 passed, **100% coverage**.
- `pre-commit run --all-files` → all hooks pass (black, flake8, mypy, isort, etc.).
- Manually ran `timezone-converter utc america/argentina/buenos_aires --single 9` and the same with `--zone`, before and after the change, and visually confirmed the fix (see above).

Closes #49


---
_Generated by [Claude Code](https://claude.ai/code/session_016P9JaM9WNHwpoL3RrT99ie)_