### PR TITLE
Gitignore coverage artifacts from the documented coverage workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__
 build
 dist
 test
+.coverage
+.coverage.*
+htmlcov


### PR DESCRIPTION
## Summary

AGENTS.md documents `coverage run -m pytest && coverage report` as the required check, which writes a `.coverage` file into the repo root. It wasn't gitignored, and an unmerged branch (`claude/timezone-converter-v1-readiness-h4ddd4`) already caught this by accidentally committing an 86KB `.coverage` binary alongside a real code change.

Added `.coverage`, `.coverage.*`, and `htmlcov` to `.gitignore` to prevent that recurring.

## Test plan

- [x] `pre-commit run --files .gitignore` — passes
- [x] `coverage run -m pytest && coverage report` — 60 passed, 100% coverage (unaffected, this is a gitignore-only change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWcHUrpPeqFhTobWeXYskv)_