### PR TITLE
docs: audit remediation plans and PR stack

### DIFF
--- a/docs/plans/2026-07-20-audit-remediation-roadmap.md
+++ b/docs/plans/2026-07-20-audit-remediation-roadmap.md
@@ -3,7 +3,7 @@
 **Status:** Proposed
 **Date:** 2026-07-20
 **Branch / worktree:** `grok/audit-fix-plans` @
-`/Users/bledy/workspace/repos/timezone-converter-audit-fix-plans`
+`/Users/bledy/workspace/worktrees/ibLeDy/timezone-converter/audit-fix-plans`
 **Source:** full repository audit (session 2026-07-20)
 
 ## Goal

--- a/docs/plans/2026-07-20-audit-remediation-roadmap.md
+++ b/docs/plans/2026-07-20-audit-remediation-roadmap.md
@@ -1,0 +1,151 @@
+# Audit remediation roadmap
+
+**Status:** Proposed
+**Date:** 2026-07-20
+**Branch / worktree:** `grok/audit-fix-plans` @
+`/Users/bledy/workspace/repos/timezone-converter-audit-fix-plans`
+**Source:** full repository audit (session 2026-07-20)
+
+## Goal
+
+Close every finding from the audit: correctness/UX, packaging honesty,
+hygiene, CLI robustness, CI/CD supply-chain, and (as a separate later
+track) optional product features. Each phase is a shippable PR with its
+own tests, 100% coverage maintained, and Conventional Commits.
+
+## Non-goals (this roadmap)
+
+- Rewriting DST day construction (already correct).
+- Replacing Rich, argparse, or the view inheritance model.
+- Force-deleting remote stale branches without explicit owner review.
+- Pinning every third-party Action to a full commit SHA on day one if
+  Dependabot is added first (Plan E chooses Dependabot + selective pins).
+
+## Global constraints (every plan)
+
+- Python 3.9 syntax only (`List`/`Optional`/`Union`; no `X | Y`, no `match`).
+- Package code stays strict-MyPy clean; tests may be loosely typed.
+- CLI flag or behavior changes update **parser, dispatch, views, tests,
+  README, tox smokes, and AGENTS.md** together.
+- DST-sensitive code requires spring-forward **and** fall-back tests
+  (and half-hour zones when hour selection changes).
+- Coverage stays **100%** (`coverage run -m pytest && coverage report`).
+- Run `pre-commit run --all-files` before claiming done.
+- No AI co-author trailers; no force-push; feature work only in
+  external worktrees per global `AGENTS.md`.
+
+## PR stack (recommended order)
+
+| PR | Plan file | Title (approx.) | Risk | Depends on |
+|----|-----------|-----------------|------|------------|
+| 1 | `2026-07-20-pr1-hygiene-docs.md` | chore: hygiene, ignore files, docstring drift | Low | — |
+| 2 | `2026-07-20-pr2-packaging.md` | fix: packaging markers and module entry | Low | — (parallel OK with 1) |
+| 3 | `2026-07-20-pr3-cli-robustness.md` | fix: CLI robustness (version, modes, exits) | Medium | 1 optional |
+| 4 | `2026-07-20-pr4-hour-wall-clock.md` | fix: `--hour` means local wall clock | **High (behavior)** | 3 recommended |
+| 5 | `2026-07-20-pr5-ci-release.md` | ci: Dependabot, release job graph, Docker smoke | Medium | 1 (dockerignore) |
+| 6 | `2026-07-20-pr6-product-enhancements.md` | feat: date/local/format + ambiguous short names | Product | 4 recommended |
+
+PRs 1 and 2 can merge in either order or as a single combined PR if
+preferred. PR 4 is intentionally last among correctness fixes because it
+is user-visible. PR 6 is optional product work called out in the audit
+as “later”; include only after 1–5 are done unless a specific feature
+is requested earlier.
+
+## Audit finding → plan map
+
+### Fixes (bugs / incorrect behavior)
+
+| Finding | Plan / PR |
+|---------|-----------|
+| `--hour N` is Nth real hour, not local wall `N:00` on DST days | PR 4 |
+| Docstring still mentions `--single` | PR 1 |
+| Unknown-timezone exit streams inconsistent (`SystemExit` str vs Rich+1) | PR 3 |
+| `build_parser()` hard-requires `tzdata` dist on every parse | PR 3 |
+| Combined modes silently prefer list > search > comparison | PR 3 |
+| Bare `--search` falls through to help | PR 3 |
+
+### Improvements
+
+| Finding | Plan / PR |
+|---------|-----------|
+| Missing `py.typed` despite `Typing :: Typed` | PR 2 |
+| No `__main__.py` (`python -m timezone_converter` fails) | PR 2 |
+| `ArgumentError(None, …)` → `ArgumentTypeError` | PR 3 |
+| Dead `setup-cfg-fmt` pre-commit hook | PR 1 |
+| Expand `.gitignore` (coverage artifacts, etc.) | PR 1 |
+| `.dockerignore` has `test` not `tests` | PR 1 |
+| `[project.optional-dependencies] dev` | PR 2 |
+| Beta → Production/Stable classifier | PR 2 (decision callout) |
+| Document `tzconv` / `python -m` in AGENTS | PR 1 |
+| Stale local editable install | note only (local hygiene) |
+
+### Additions (process / product)
+
+| Finding | Plan / PR |
+|---------|-----------|
+| Dependabot for Actions / pre-commit / pip | PR 5 |
+| Safer release job graph (no half-publish) | PR 5 |
+| Docker smoke after image build | PR 5 |
+| CHANGELOG.md process | PR 5 (lightweight) + RELEASE.md |
+| SECURITY.md | PR 5 |
+| `--date`, `--local`, `--format`, ambiguous short-name warn | PR 6 |
+| Python 3.14 matrix | PR 5 or follow-up when ready |
+
+### Deletions / cleanup
+
+| Finding | Plan / PR |
+|---------|-----------|
+| Remove `setup-cfg-fmt` hook | PR 1 |
+| Drop or keep `develop` CI branch trigger | PR 5 (document choice: keep unless confirmed unused) |
+| Dead `returncode is None` branch | PR 3 (keep safety + test, or tighten types—plan chooses keep) |
+| Remote stale branches | **Out of band** — list in PR 5 notes; do not auto-delete |
+
+### Security
+
+| Finding | Plan / PR |
+|---------|-----------|
+| Image includes `tests/` | PR 1 |
+| Unpinned Action tags | PR 5 (Dependabot first) |
+| PyPI before Docker failure | PR 5 |
+| Base image digest pin | PR 5 (optional stretch; tag + Dependabot default) |
+
+### Performance
+
+No code changes planned. Import ~80 ms is acceptable. Revisit only if
+profiling shows a regression after PR 2/3 map changes (none expected).
+
+### Testing gaps closed by plans
+
+| Gap | Plan |
+|-----|------|
+| `--hour` on DST days | PR 4 |
+| CLI unknown zone exit/stream | PR 3 |
+| Mode mutual exclusion | PR 3 |
+| Bare `--search` | PR 3 |
+| Fall-back highlight assert | PR 4 (or PR 3 if isolated) |
+| `tzconv` / `__main__` smoke | PR 2 tox |
+| Docker smoke in CI | PR 5 |
+
+## Versioning and release
+
+- **Do not** bump `project.version` inside hygiene/docs-only PRs.
+- PR 4 (`--hour` behavior) is a **behavior change**: include in the
+  next minor (e.g. `0.17.0`) release notes; do not ship silently in a
+  patch if users rely on index semantics (unlikely but document it).
+- PR 6 features → minor version bumps as shipped.
+- Follow `RELEASE.md` for tagging (`vX.Y.Z` or `X.Y.Z`).
+
+## Execution guidance
+
+1. Create one external worktree/branch per PR from latest `origin/main`
+   (or restack Graphite-style if preferred):
+   `grok/audit-hygiene`, `grok/audit-packaging`, etc.
+2. Prefer TDD for behavioral changes (PR 3, PR 4, PR 6).
+3. After each PR: coverage 100%, pre-commit clean, open/update PR,
+   mark ready when checks pass.
+4. Update this roadmap **Outcome** section when a PR merges.
+
+## Outcome
+
+_Not yet implemented. Fill on completion: dates, PR URLs, deviations,
+validation, remaining work._

--- a/docs/plans/2026-07-20-pr1-hygiene-docs.md
+++ b/docs/plans/2026-07-20-pr1-hygiene-docs.md
@@ -1,0 +1,246 @@
+# PR 1: Hygiene, ignore files, docstring drift
+
+> **For agentic workers:** Implement task-by-task. Steps use checkbox
+> (`- [ ]`) syntax for tracking. Keep this PR low-risk and free of
+> behavior changes.
+
+**Status:** Proposed
+**Goal:** Fix doc drift, ignore-file bugs, and dead tooling without
+changing CLI behavior.
+**Architecture:** Config and comment-only edits plus docstring text;
+no runtime logic changes.
+**Tech stack:** existing pre-commit, git ignore, Markdown docs.
+
+## Global constraints
+
+See `docs/plans/2026-07-20-audit-remediation-roadmap.md`. No version bump.
+
+## File map
+
+| File | Change |
+|------|--------|
+| `.dockerignore` | Ignore `tests/`, agent docs, coverage junk; drop useless `test` |
+| `.gitignore` | Coverage/cache artifacts |
+| `.pre-commit-config.yaml` | Remove `setup-cfg-fmt` repo block |
+| `timezone_converter/main.py` | Docstring: `--single` → `--hour`, list real flags |
+| `timezone_converter/comparison_view.py` | Document `difference` param |
+| `AGENTS.md` / `CLAUDE.md` | `tzconv`, `python -m timezone_converter` after PR 2 note as upcoming or list both entry forms |
+| `README.md` | Only if a hygiene-related inaccuracy remains (usually none) |
+
+---
+
+### Task 1: Fix `.dockerignore`
+
+**Files:**
+- Modify: `.dockerignore`
+
+- [ ] **Step 1: Replace contents** with:
+
+```
+.git
+.github
+.mypy_cache
+.pre-commit-config.yaml
+.pytest_cache
+.venv
+.tox
+*.egg-info
+build
+dist
+requirements-dev.txt
+tests
+docs
+AGENTS.md
+CLAUDE.md
+RELEASE.md
+.coverage
+htmlcov
+coverage.xml
+.ruff_cache
+```
+
+Rationale: `test` never matched `tests/`; image was shipping the suite.
+Keep `LICENSE` and `README.md` and package sources for `pip install .`.
+
+- [ ] **Step 2: Sanity-check** (no Docker required if unavailable):
+
+```bash
+# From worktree root — list what would be sent as context (if docker installed)
+docker build --dry-run . 2>/dev/null || python - <<'PY'
+from pathlib import Path
+text = Path('.dockerignore').read_text().splitlines()
+assert 'tests' in text
+assert 'test' not in text or any(line.strip() == 'tests' for line in text)
+print('dockerignore ok')
+PY
+```
+
+Expected: assertion passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .dockerignore
+git commit -m "chore: exclude tests and docs from Docker build context"
+```
+
+---
+
+### Task 2: Expand `.gitignore`
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Append** (keep existing entries):
+
+```
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+.ruff_cache/
+.dmypy.json
+.DS_Store
+```
+
+Keep the existing bare `test` entry (legacy; does not ignore `tests/`).
+Do **not** add `tests` to gitignore.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: ignore coverage and local tool caches"
+```
+
+---
+
+### Task 3: Remove dead `setup-cfg-fmt` hook
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Delete** the entire repo block:
+
+```yaml
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v3.2.0
+    hooks:
+      - id: setup-cfg-fmt
+        args:
+          - "--include-version-classifiers"
+```
+
+(There is no `setup.cfg` in the project.)
+
+- [ ] **Step 2: Run**
+
+```bash
+pre-commit run --all-files
+```
+
+Expected: hooks pass (or only pre-existing issues unrelated to this deletion).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "chore: drop unused setup-cfg-fmt pre-commit hook"
+```
+
+---
+
+### Task 4: Fix docstrings
+
+**Files:**
+- Modify: `timezone_converter/main.py` (module docstring of `build_parser`)
+- Modify: `timezone_converter/comparison_view.py` (`__init__` Parameters)
+
+- [ ] **Step 1: Update `build_parser` docstring** to list actual flags:
+
+```python
+    """Build the command-line argument parser.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Parser configured with the ``timezone``, ``--list``, ``--version``,
+        ``--zone``, ``--hour``, ``--search``, ``--order``, and
+        ``--difference`` arguments.
+    """
+```
+
+- [ ] **Step 2: Add `difference` to `ComparisonView.__init__` Parameters**
+  (after `order`):
+
+```python
+        order : bool
+            If ``True``, sort the foreign timezones by absolute offset
+            from the local timezone.
+        difference : bool
+            If ``True``, append each foreign column's signed hour offset
+            from the local timezone to the header (e.g. ``+5h``).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add timezone_converter/main.py timezone_converter/comparison_view.py
+git commit -m "docs: align parser and ComparisonView docstrings with CLI"
+```
+
+---
+
+### Task 5: Agent docs — entry points
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `CLAUDE.md` (keep in sync if it remains a full copy)
+
+- [ ] **Step 1: Update Commands section** run line to:
+
+```markdown
+- Run: `timezone-converter` / `tzconv` `<timezone> [<timezone> ...]` or
+  `python -m timezone_converter.main`
+  (after packaging PR: also `python -m timezone_converter`)
+```
+
+If this PR merges **before** PR 2, document only what works today:
+
+```markdown
+- Run: `timezone-converter` or `tzconv` `<timezone> [...]`, or
+  `python -m timezone_converter.main`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add AGENTS.md CLAUDE.md
+git commit -m "docs: document tzconv entry point for agents"
+```
+
+---
+
+### Task 6: Verify no behavior change
+
+- [ ] **Step 1: Run tests**
+
+```bash
+pip install -e . -r requirements-dev.txt   # if needed
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 coverage run -m pytest
+coverage report
+```
+
+Expected: 100% coverage, all pass.
+
+- [ ] **Step 2: Open PR** titled roughly
+  `chore: Docker/git ignore hygiene and docstring drift`
+  Body links this plan and the roadmap. No behavior-change section needed.
+
+---
+
+## Self-review checklist
+
+- [x] All PR 1 audit items mapped (dockerignore, gitignore, setup-cfg-fmt, docstrings, AGENTS).
+- [x] No placeholders requiring “fill in later.”
+- [x] No runtime behavior change intended.

--- a/docs/plans/2026-07-20-pr2-packaging.md
+++ b/docs/plans/2026-07-20-pr2-packaging.md
@@ -1,0 +1,270 @@
+# PR 2: Packaging markers and module entry
+
+> **For agentic workers:** Implement task-by-task with TDD where
+> behavior is observable. Checkbox (`- [ ]`) tracking.
+
+**Status:** Proposed
+**Goal:** Make packaging claims honest (`Typing :: Typed`), support
+`python -m timezone_converter`, and modernize dev extras.
+**Architecture:** Add static package data (`py.typed`, `__main__.py`);
+extend `pyproject.toml` only. No timezone math changes.
+**Tech stack:** hatchling, importlib.metadata, existing entry points.
+
+## Global constraints
+
+See roadmap. Prefer no version bump (packaging fix). If you flip the
+Development Status classifier to Production/Stable, call that out in
+the PR body as an intentional product decision.
+
+## File map
+
+| File | Change |
+|------|--------|
+| `timezone_converter/py.typed` | Create empty marker (PEP 561) |
+| `timezone_converter/__main__.py` | `sys.exit(main())` |
+| `pyproject.toml` | optional-deps `dev`; tox smoke for `-m timezone_converter`; optional classifier |
+| `tests/main_test.py` or new `tests/package_test.py` | entry / marker tests if useful |
+| `AGENTS.md` | document `python -m timezone_converter` once implemented |
+| `README.md` | optional one-liner under Installation for module form |
+
+---
+
+### Task 1: `py.typed` marker
+
+**Files:**
+- Create: `timezone_converter/py.typed`
+- Verify: hatch wheel includes package data by default for package dir
+
+- [ ] **Step 1: Create empty file** `timezone_converter/py.typed`
+  (zero bytes or a single blank line is fine; empty is conventional).
+
+- [ ] **Step 2: Confirm hatch includes it**
+
+```bash
+pip install -e . build
+python -m build --wheel --outdir=/tmp/tzc-dist
+python - <<'PY'
+import zipfile
+from pathlib import Path
+wheels = list(Path('/tmp/tzc-dist').glob('*.whl'))
+assert wheels, 'no wheel'
+with zipfile.ZipFile(wheels[0]) as zf:
+    names = zf.namelist()
+assert any(n.endswith('timezone_converter/py.typed') for n in names), names
+print('py.typed in wheel OK')
+PY
+```
+
+Expected: prints `py.typed in wheel OK`.
+
+If the marker is missing from the wheel, add under
+`[tool.hatch.build.targets.wheel]`:
+
+```toml
+[tool.hatch.build.targets.wheel]
+packages = [
+    "timezone_converter",
+]
+# only if needed — hatchling normally includes package data next to modules
+```
+
+Or set:
+
+```toml
+[tool.hatch.build]
+include = [
+  "timezone_converter/py.typed",
+]
+```
+
+Only if Step 2 fails.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add timezone_converter/py.typed
+git commit -m "fix: ship PEP 561 py.typed marker for Typing :: Typed"
+```
+
+---
+
+### Task 2: `__main__.py` entry
+
+**Files:**
+- Create: `timezone_converter/__main__.py`
+- Modify: `tests/main_test.py` (add test)
+- Modify: `pyproject.toml` tox commands
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Write failing test** in `tests/main_test.py`:
+
+```python
+import subprocess
+import sys
+
+
+def test_python_module_package_entry_runs_help():
+    proc = subprocess.run(
+        [sys.executable, '-m', 'timezone_converter', '--help'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert 'timezone-converter' in proc.stdout
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/main_test.py::test_python_module_package_entry_runs_help -v
+```
+
+Expected: fail with `No module named timezone_converter.__main__` (or
+non-zero returncode).
+
+- [ ] **Step 3: Implement** `timezone_converter/__main__.py`:
+
+```python
+from timezone_converter.main import main
+
+if __name__ == '__main__':
+    raise SystemExit(main())
+```
+
+Use `raise SystemExit(main())` rather than bare `exit()` for consistency
+with library-friendly module execution.
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/main_test.py::test_python_module_package_entry_runs_help -v
+```
+
+- [ ] **Step 5: Add tox smoke** in `pyproject.toml` `[tool.tox]`
+  `commands` list (after existing smokes):
+
+```
+    python -m timezone_converter --help
+    tzconv --version
+```
+
+(`tzconv --version` may already exist; do not duplicate.)
+
+- [ ] **Step 6: Update AGENTS.md** Commands:
+
+```markdown
+- Run: `timezone-converter` / `tzconv` `<timezone> [...]` or
+  `python -m timezone_converter` (equivalent to
+  `python -m timezone_converter.main`)
+```
+
+- [ ] **Step 7: Full suite + commit**
+
+```bash
+coverage run -m pytest && coverage report
+git add timezone_converter/__main__.py tests/main_test.py pyproject.toml AGENTS.md CLAUDE.md
+git commit -m "feat: support python -m timezone_converter via __main__"
+```
+
+---
+
+### Task 3: Optional dev dependencies
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `requirements-dev.txt` (keep as thin wrapper or mirror)
+- Modify: `AGENTS.md` install line
+- Modify: `RELEASE.md` if it mentions only requirements-dev
+
+- [ ] **Step 1: Add to `pyproject.toml`:**
+
+```toml
+[project.optional-dependencies]
+dev = [
+    "covdefaults",
+    "coverage",
+    "pre-commit",
+    "pytest",
+    "tox",
+    "tox-gh-actions",
+]
+```
+
+Keep `requirements-dev.txt` in sync (same pins/unpinned list) so
+existing docs keep working:
+
+```
+# Mirror of [project.optional-dependencies] dev — prefer:
+#   pip install -e ".[dev]"
+covdefaults
+coverage
+pre-commit
+pytest
+tox
+tox-gh-actions
+```
+
+- [ ] **Step 2: Update AGENTS install line:**
+
+```markdown
+- Install: `pip install -e ".[dev]"` (or `pip install -e .` and
+  `pip install -r requirements-dev.txt`)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml requirements-dev.txt AGENTS.md CLAUDE.md RELEASE.md
+git commit -m "chore: add optional dev extras matching requirements-dev"
+```
+
+---
+
+### Task 4: Development Status classifier (decision)
+
+**Files:**
+- Modify: `pyproject.toml` classifiers (optional)
+
+- [ ] **Step 1: Decide with maintainer default:**
+  **Recommended:** change to
+  `"Development Status :: 5 - Production/Stable"`
+  given multi-year releases, 100% coverage, and multi-OS CI.
+  If the maintainer prefers staying Beta until PR 4 ships, **skip**
+  this task and note it in the PR body.
+
+- [ ] **Step 2: If changing:**
+
+```toml
+    "Development Status :: 5 - Production/Stable",
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "chore: mark Development Status as Production/Stable"
+```
+
+---
+
+### Task 5: Verification
+
+- [ ] **Step 1:**
+
+```bash
+coverage run -m pytest && coverage report
+pre-commit run --all-files
+python -m timezone_converter --help
+tzconv --version   # after reinstall: pip install -e ".[dev]"
+```
+
+- [ ] **Step 2: Open PR**
+  `fix: packaging py.typed, __main__, and dev extras`
+
+---
+
+## Self-review checklist
+
+- [x] `Typing :: Typed` honesty via `py.typed`.
+- [x] Module execution path covered by test + tox.
+- [x] Dev extras do not replace runtime deps.

--- a/docs/plans/2026-07-20-pr3-cli-robustness.md
+++ b/docs/plans/2026-07-20-pr3-cli-robustness.md
@@ -1,0 +1,416 @@
+# PR 3: CLI robustness (version, modes, exits)
+
+> **For agentic workers:** TDD for each behavioral change. Checkbox
+> tracking. Preserve view exit-code contracts (0 success, nonzero fail).
+
+**Status:** Proposed
+**Goal:** Make parser construction safe without installed `tzdata`
+metadata side effects; make mode selection explicit; unify unknown-zone
+errors; use idiomatic argparse type errors.
+**Architecture:** Keep `main.main()` as dispatcher. Unknown zones return
+exit codes from comparison path instead of mixed `SystemExit` strings
+where practical; keep process exit nonzero.
+**Tech stack:** argparse, importlib.metadata, Rich (stderr policy).
+
+## Global constraints
+
+See roadmap. Coordinated CLI changes: parser + tests + README (if UX
+text changes) + tox as needed. Python 3.9 typing style.
+
+## Design decisions (locked for this plan)
+
+1. **`tzdata` version:** Resolve only for the version action string;
+   if `PackageNotFoundError`, show `tzdata unknown` (or `tzdata (not installed as package)`). Parser construction must not raise.
+2. **Mode exclusivity:** Exactly one of: list mode, search mode,
+   comparison mode (one or more timezones), or help. If more than one
+   of `{list is not None, search is not None, timezone non-empty}` is
+   active, print a short error to stderr and return `2` (argparse-like).
+3. **Bare `--search`:** Change `--search` to `nargs=1` **or** keep
+   `nargs='?'` but treat `const` specially. **Chosen:** require a word:
+   use `nargs=None` default (single required value when flag present):
+
+   ```python
+   parser.add_argument('-S', '--search', type=str.lower, metavar='WORD', ...)
+   ```
+
+   Then bare `--search` is argparse error (exit 2). Empty string still
+   possible as `--search ''` — keep SearchView empty behavior.
+4. **Unknown timezone:** Stop using `SystemExit(error_msg)`. Instead:
+   - print error (and suggestions table) via a single helper that writes
+     with Rich Console on **stderr** (`Console(stderr=True)`), then
+     `raise SystemExit(1)` **or** return `1` from constructor path.
+   - **Chosen approach:** change `_get_timezone_name` to return
+     `Optional[str]` and have `__init__` collect failures…
+     **Simpler chosen approach:** introduce
+     `Helper._print_error_with_rich(obj)` using `Console(stderr=True)`,
+     always `raise SystemExit(1)` after printing (never
+     `SystemExit(str)`). Tests assert returncode 1 and message location.
+5. **Keep** `returncode is None → 1` safety net and existing test.
+6. **`ArgumentTypeError`** for `_hour_value` and `_list_letter`.
+
+## File map
+
+| File | Change |
+|------|--------|
+| `timezone_converter/main.py` | version helper, mode check, search nargs, ArgumentTypeError |
+| `timezone_converter/helper.py` | optional `_print_error_with_rich` |
+| `timezone_converter/comparison_view.py` | unified SystemExit(1) + stderr print |
+| `tests/main_test.py` | version without tzdata, modes, bare search, type errors |
+| `tests/comparison_view_test.py` | exit code / stderr for unknown zones |
+| `README.md` | note that flags are exclusive if user-facing |
+
+---
+
+### Task 1: ArgumentTypeError converters
+
+**Files:**
+- Modify: `timezone_converter/main.py`
+- Modify: `tests/main_test.py`
+
+- [ ] **Step 1: Update tests** for invalid hour/list to still raise
+  (argparse wraps type errors). Existing tests use
+  `pytest.raises(argparse.ArgumentError)` when calling converters
+  directly — change direct converter tests to:
+
+```python
+def test_hour_value_invalid():
+    with pytest.raises(argparse.ArgumentTypeError):
+        _hour_value('24')
+
+
+def test_list_letter_rejects_digits():
+    with pytest.raises(argparse.ArgumentTypeError):
+        _list_letter('a1')
+```
+
+- [ ] **Step 2: Implement converters:**
+
+```python
+def _hour_value(argument: str) -> int:
+    try:
+        hour = int(argument)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f'invalid hour value: {argument!r}',
+        ) from None
+    if hour not in range(24):
+        raise argparse.ArgumentTypeError(
+            'Value for --hour must be between 00 and 23',
+        )
+    return hour
+
+
+def _list_letter(argument: str) -> List[str]:
+    argument_set = set(argument.lower())
+    if any(not arg.isalpha() for arg in argument_set):
+        raise argparse.ArgumentTypeError(
+            'Values for --list cannot contain numbers',
+        )
+    return sorted(argument_set)
+```
+
+- [ ] **Step 3: Run targeted tests; commit**
+
+```bash
+pytest tests/main_test.py -k 'hour_value or list_letter' -v
+git add timezone_converter/main.py tests/main_test.py
+git commit -m "fix: use ArgumentTypeError in CLI type converters"
+```
+
+---
+
+### Task 2: Safe version string (lazy tzdata)
+
+**Files:**
+- Modify: `timezone_converter/main.py`
+- Modify: `tests/main_test.py`
+
+- [ ] **Step 1: Failing test** — parser builds even if tzdata metadata missing:
+
+```python
+def test_build_parser_without_tzdata_package(monkeypatch):
+    def _boom(_name):
+        raise importlib.metadata.PackageNotFoundError('tzdata')
+
+    monkeypatch.setattr(
+        'timezone_converter.main.importlib.metadata.version',
+        _boom,
+    )
+    # VERSION lookup also uses metadata — only patch the call site helper.
+    # Prefer testing the helper directly:
+```
+
+Better structure — add helper and test it:
+
+```python
+# main.py
+def _tzdata_version_label() -> str:
+    try:
+        return importlib.metadata.version('tzdata')
+    except importlib.metadata.PackageNotFoundError:
+        return 'unknown'
+
+
+# In build_parser:
+# version=f'%(prog)s {VERSION} (tzdata {_tzdata_version_label()})',
+# MUST NOT call version('tzdata') at import of build_parser beyond this helper.
+```
+
+Note: `action='version'` evaluates the version string when the action
+runs if we pass a string — still computed at `build_parser()` time if
+we format immediately. **Use a custom version action or format at
+build time via the safe helper** (helper must not raise):
+
+```python
+    parser.add_argument(
+        '-V',
+        '--version',
+        action='version',
+        version=f'%(prog)s {VERSION} (tzdata {_tzdata_version_label()})',
+        help="show program's version number and exit",
+    )
+```
+
+Test:
+
+```python
+import importlib.metadata
+
+def test_tzdata_version_label_unknown(monkeypatch):
+    def _boom(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, 'version', _boom)
+    from timezone_converter.main import _tzdata_version_label
+    assert _tzdata_version_label() == 'unknown'
+
+
+def test_build_parser_does_not_raise_without_tzdata(monkeypatch):
+    monkeypatch.setattr(
+        'timezone_converter.main._tzdata_version_label',
+        lambda: 'unknown',
+    )
+    args = build_parser().parse_args(['tijuana'])
+    assert args.timezone == ['tijuana']
+```
+
+- [ ] **Step 2: Implement helper; remove bare
+  `importlib.metadata.version('tzdata')` without try/except.**
+
+- [ ] **Step 3: Keep existing test
+  `test_build_parser_version_includes_tzdata_version`** — still expects
+  `tzdata \d` when package present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "fix: tolerate missing tzdata distribution in --version"
+```
+
+---
+
+### Task 3: Require search word; mode exclusivity
+
+**Files:**
+- Modify: `timezone_converter/main.py`
+- Modify: `tests/main_test.py`
+- Modify: `README.md` (brief note under Usage if helpful)
+
+- [ ] **Step 1: Tests**
+
+```python
+def test_search_requires_word(capsys):
+    with pytest.raises(SystemExit) as exc:
+        build_parser().parse_args(['--search'])
+    assert exc.value.code == 2
+
+
+def test_main_rejects_list_and_timezone(monkeypatch, capsys):
+    monkeypatch.setattr('sys.argv', ['tz', 'tijuana', '--list', 'a'])
+    assert main() == 2
+    err = capsys.readouterr().err
+    assert 'not combine' in err.lower() or 'exclusive' in err.lower()
+
+
+def test_main_rejects_search_and_timezone(monkeypatch, capsys):
+    monkeypatch.setattr('sys.argv', ['tz', 'tijuana', '--search', 'york'])
+    assert main() == 2
+```
+
+- [ ] **Step 2: Change `--search` definition** to require WORD:
+
+```python
+    parser.add_argument(
+        '-S',
+        '--search',
+        type=str.lower,
+        metavar='WORD',
+        help='fuzzy search for a timezone',
+    )
+```
+
+- [ ] **Step 3: Dispatch with exclusivity**
+
+Prefer `return 2` (testable via `main()`) over `parser.exit()`:
+
+```python
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    modes = [
+        args.list is not None,
+        args.search is not None,
+        bool(args.timezone),
+    ]
+    if sum(modes) > 1:
+        sys.stderr.write(
+            'error: --list, --search, and timezone arguments '
+            'are mutually exclusive\n',
+        )
+        return 2
+
+    returncode: Optional[int] = 0
+    if args.list is not None:
+        returncode = ListView(args.list).print_columns()
+    elif args.search is not None:
+        returncode = SearchView(args.search).print_search_results()
+    elif args.timezone:
+        returncode = ComparisonView(
+            args.timezone,
+            args.zone,
+            args.hour,
+            args.order,
+            args.difference,
+        ).print_table()
+    else:
+        parser.print_help()
+
+    if returncode is None:
+        returncode = 1
+    return returncode
+```
+
+Add `import sys` at the top of `main.py`.
+
+**Important:** `--list` uses `nargs='?'` with `const=all letters`. When
+the flag is absent, `args.list is None`. When present without value,
+`args.list` is the full alphabet. Current code used `if args.list:`
+which treats empty list as false — exclusivity must use
+`is not None` for list/search.
+
+Empty list after filter is still a valid list mode (print nothing).
+Existing `ListView(['x'])` tests remain valid.
+
+Update any tests that assumed `if args.list:` truthiness if needed.
+
+- [ ] **Step 4: README** — under Useful flags, one line:
+
+```markdown
+`--list`, `--search`, and timezone arguments are mutually exclusive.
+```
+
+- [ ] **Step 5: Full tests + commit**
+
+```bash
+coverage run -m pytest && coverage report
+git commit -am "fix: exclusive CLI modes and required --search WORD"
+```
+
+---
+
+### Task 4: Unified unknown-timezone errors on stderr
+
+**Files:**
+- Modify: `timezone_converter/helper.py`
+- Modify: `timezone_converter/comparison_view.py`
+- Modify: `tests/comparison_view_test.py`
+
+- [ ] **Step 1: Add helper**
+
+```python
+# helper.py
+@staticmethod
+def _print_error_with_rich(obj: Union[str, Columns, Table]) -> None:
+    Console(stderr=True).print(obj)
+```
+
+- [ ] **Step 2: Change `_get_timezone_name`**
+
+```python
+    def _get_timezone_name(self, timezone: str) -> str:
+        timezone_name = self.resolve_timezone(timezone)
+        if timezone_name is None:
+            error_msg = f'error: {timezone!r} is not an available timezone'
+            possible_matches: List[str] = get_close_matches(
+                timezone.lower(),
+                self.searchable_timezones,
+                n=5,
+            )
+            self._print_error_with_rich(error_msg)
+            if possible_matches:
+                table = Table()
+                table.add_column('Closest matches')
+                for match in possible_matches:
+                    table.add_row(match)
+                self._print_error_with_rich(table)
+            raise SystemExit(1)
+        return timezone_name
+```
+
+- [ ] **Step 3: Tests** (subprocess or capsys with stderr):
+
+```python
+def test_unknown_timezone_exits_one_with_message(capsys):
+    with pytest.raises(SystemExit) as exc:
+        _make_view(['zzzzzzzzzz'])
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert 'zzzzzzzzzz' in captured.err
+    assert captured.out == ''
+
+
+def test_unknown_timezone_suggestions_on_stderr(capsys):
+    with pytest.raises(SystemExit) as exc:
+        _make_view(['new_yrk'])
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert 'new_york' in err
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "fix: print unknown timezone errors on stderr with exit 1"
+```
+
+---
+
+### Task 5: Verification and PR
+
+- [ ] **Step 1:**
+
+```bash
+coverage run -m pytest && coverage report
+pre-commit run --all-files
+timezone-converter --version
+timezone-converter --search   # expect usage error
+timezone-converter tijuana --list a  # expect exclusive error
+```
+
+- [ ] **Step 2: Open PR**
+  `fix: harden CLI parsing, mode exclusivity, and error output`
+  Label as mild behavior change (exclusive modes, bare `--search`).
+
+## Behavior change summary (for PR body)
+
+- Bare `--search` now errors (exit 2) instead of printing help.
+- Combining `--list`/`--search`/timezones errors (exit 2) instead of silent precedence.
+- Unknown zone messages go to stderr; always exit code 1.
+- Missing `tzdata` package no longer crashes parser construction.
+
+## Self-review checklist
+
+- [x] All PR 3 audit items covered.
+- [x] `--list is not None` vs truthiness called out.
+- [x] Tests specified for exclusivity and stderr.

--- a/docs/plans/2026-07-20-pr4-hour-wall-clock.md
+++ b/docs/plans/2026-07-20-pr4-hour-wall-clock.md
@@ -1,0 +1,258 @@
+# PR 4: `--hour` means local wall-clock hour
+
+> **For agentic workers:** This is a **user-visible behavior change**.
+> TDD required. Add spring-forward, fall-back, and half-hour zone tests.
+> Checkbox tracking.
+
+**Status:** Proposed
+**Goal:** Make `--hour N` select the row whose **local** clock time is
+`N:00` on the local calendar day (or the defined fallback when that
+local time does not exist).
+**Architecture:** Build the single-hour instant from the local date +
+`time(hour=N)` via the `_to_local` seam / zone-aware construction, not
+`base_utc + timedelta(hours=N)`. Full-day tables stay on
+`_day_instants()`.
+**Tech stack:** datetime, ZoneInfo, existing ComparisonView.
+
+## Global constraints
+
+See roadmap. Document BEHAVIOR CHANGE in PR body and README. Prefer
+shipping in **0.17.0** notes (version bump can be a follow-up release
+commit, not necessarily this PR).
+
+## Semantic specification (normative)
+
+Let `D` be the local calendar date of `base_instant` (local midnight’s
+date). Let `H` be the integer `--hour` in `0..23`.
+
+1. **Normal days:** Show the unique local instant `D H:00` converted
+   across all columns (aware UTC under the hood).
+2. **Spring-forward gap** (e.g. `H=2` when 02:00 does not exist):
+   **Policy:** use the first valid local time at or after `H:00` on
+   date `D` (typically `03:00`). Document this. Alternative rejected:
+   error exit — worse UX for a display tool.
+3. **Fall-back fold** (e.g. two `01:00` instants):
+   **Policy:** use the **first** occurrence (earlier UTC / DST still in
+   effect), matching “start of that clock hour” intuition.
+4. **Half-hour offsets (Lord Howe etc.):** Local times may be `HH:30`
+   for “top of hour” displays already in full-day mode. For `--hour N`,
+   still target local `N:00` if it exists on that day; if the zone’s
+   civil times are only `:30` after transition, follow the same
+   fold/gap rules using `datetime` + `ZoneInfo` fold semantics.
+
+Implementation should use `zoneinfo`/`datetime` correctly rather than
+string matching.
+
+## Recommended implementation sketch
+
+```python
+from datetime import time as dt_time
+
+def _hour_instant(self) -> datetime:
+    """UTC instant for local civil hour ``self.hour`` on the local day."""
+    assert self.hour is not None
+    local_mid = _to_local(self.base_instant)
+    # Naive civil datetime in local zone
+    civil = datetime(
+        local_mid.year,
+        local_mid.month,
+        local_mid.day,
+        self.hour,
+        0,
+        0,
+    )
+    # Attach local tz. On systems under test, _to_local is monkeypatched;
+    # production local zone is the system zone.
+    local_tz = local_mid.tzinfo
+    if local_tz is None:
+        # Should not happen — base_instant is aware
+        aware = civil.astimezone()
+    else:
+        # fold=0 → first occurrence on ambiguous hours
+        aware = civil.replace(tzinfo=local_tz, fold=0)
+        # If spring-forward made this wall time invalid, ZoneInfo may
+        # still accept and adjust; verify with tests per platform.
+        # Portable approach: search _day_instants() for matching local hour.
+    return aware.astimezone(datetime_timezone.utc)
+```
+
+**Portable approach preferred (matches existing DST tests style):**
+
+```python
+def _instant_for_local_hour(self, hour: int) -> datetime:
+    matches = [
+        inst for inst in self._day_instants()
+        if _to_local(inst).hour == hour and _to_local(inst).minute == 0
+    ]
+    if matches:
+        return matches[0]  # first = fold preference
+    # Gap: no exact HH:00 — pick first instant whose local time is > hour:00
+    # or the first instant after the gap with local.hour > hour
+    for inst in self._day_instants():
+        local = _to_local(inst)
+        if (local.hour, local.minute) > (hour, 0):
+            return inst
+    # Fallback: last instant of the day (should be rare)
+    return self._day_instants()[-1]
+```
+
+Then `_build_table`:
+
+```python
+        if self.hour is not None:
+            instants = [self._instant_for_local_hour(self.hour)]
+        else:
+            instants = self._day_instants()
+```
+
+This reuses DST-correct `_day_instants()` and stays cross-platform with
+the `_to_local` monkeypatch.
+
+## File map
+
+| File | Change |
+|------|--------|
+| `timezone_converter/comparison_view.py` | `_instant_for_local_hour`, `_build_table` |
+| `tests/comparison_view_test.py` | DST hour tests; update any index-based assumptions |
+| `README.md` | Document wall-clock meaning + gap policy |
+| `AGENTS.md` | Note hour selection policy under architecture |
+
+---
+
+### Task 1: Failing tests for wall-clock semantics
+
+**Files:**
+- Modify: `tests/comparison_view_test.py`
+
+- [ ] **Step 1: Add tests** (using existing `local_timezone` fixture):
+
+```python
+def test_hour_selects_local_wall_clock_on_spring_forward_day(local_timezone):
+    zone = local_timezone('America/New_York')
+    view = _make_view(['london'], hour=14)
+    view.base_instant = datetime(2026, 3, 8, tzinfo=zone)
+    cells = list(view._build_table().columns[0]._cells)
+    assert cells == ['2026-03-08 14:00']
+
+
+def test_hour_two_on_spring_forward_uses_post_gap_time(local_timezone):
+    # 02:00 does not exist; policy → first local time after gap with hour>=2
+    # typically 03:00
+    zone = local_timezone('America/New_York')
+    view = _make_view(['london'], hour=2)
+    view.base_instant = datetime(2026, 3, 8, tzinfo=zone)
+    cells = list(view._build_table().columns[0]._cells)
+    assert cells == ['2026-03-08 03:00']
+
+
+def test_hour_one_on_fall_back_uses_first_occurrence(local_timezone):
+    zone = local_timezone('America/New_York')
+    view = _make_view(['london'], hour=1)
+    view.base_instant = datetime(2026, 11, 1, tzinfo=zone)
+    # First 01:00 is EDT (UTC-4) — assert via UTC instant or single local cell
+    local_cell = list(view._build_table().columns[0]._cells)[0]
+    assert local_cell == '2026-11-01 01:00'
+    # Ensure we did not pick an arbitrary later row: only one row
+    assert len(view._build_table().rows) == 1
+
+
+def test_hour_zero_still_single_row_wall_clock(local_timezone):
+    zone = local_timezone('America/New_York')
+    view = _make_view(['new_york'], hour=0, zone=True)
+    view.base_instant = datetime(2026, 6, 1, tzinfo=zone)
+    table = view._build_table()
+    assert len(table.rows) == 1
+    assert list(table.columns[0]._cells) == ['2026-06-01 00:00']
+```
+
+- [ ] **Step 2: Run — expect FAIL** on spring-forward hour=14 (currently
+  yields 15:00 under local NY).
+
+```bash
+pytest tests/comparison_view_test.py -k 'hour_selects_local or hour_two_on_spring' -v
+```
+
+---
+
+### Task 2: Implement `_instant_for_local_hour`
+
+**Files:**
+- Modify: `timezone_converter/comparison_view.py`
+
+- [ ] **Step 1: Implement** method as in the portable sketch above.
+- [ ] **Step 2: Wire `_build_table`** to use it when `self.hour is not None`.
+- [ ] **Step 3: Run new tests + full suite.**
+
+```bash
+coverage run -m pytest && coverage report
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "fix: interpret --hour as local wall-clock hour across DST"
+```
+
+---
+
+### Task 3: Highlight regression guard on fall-back
+
+- [ ] **Step 1: Optional test** — when `now` falls in the first repeated
+  hour window, exactly one row is blue (full-day mode). Can monkeypatch
+  `datetime.now` if needed. Skip if already covered by
+  `test_current_hour_row_is_highlighted` stability.
+
+- [ ] **Step 2: Commit if added.**
+
+---
+
+### Task 4: Docs
+
+**Files:**
+- Modify: `README.md` “Output a single hour” section
+- Modify: `AGENTS.md` architecture bullet
+
+README addition:
+
+```markdown
+### Output a single hour
+
+Using the `--hour` argument, you can output a single hour. If you don't
+provide a value, the current hour will be displayed.
+
+`--hour N` selects local wall-clock time `N:00` on today's local date.
+On spring-forward days, if that local time does not exist, the first
+valid local time after the gap is shown. On fall-back days with a
+repeated hour, the first occurrence is shown.
+```
+
+AGENTS.md bullet:
+
+```markdown
+- `--hour N` means local wall-clock `N:00` (first occurrence on fold;
+  first valid time after gap on spring-forward), not the Nth UTC step
+  from midnight.
+```
+
+- [ ] **Step 1: Edit docs and commit**
+
+```bash
+git commit -am "docs: define --hour wall-clock and DST gap/fold policy"
+```
+
+---
+
+### Task 5: PR
+
+- [ ] Open PR titled
+  `fix: make --hour select local wall-clock time (DST-safe)`
+- [ ] PR body includes **BEHAVIOR CHANGE** section with before/after
+  example (NY spring-forward `--hour 14`: was 15:00, now 14:00).
+- [ ] Suggest release notes under 0.17.0.
+
+## Self-review checklist
+
+- [x] Normative semantics for gap and fold.
+- [x] Portable implementation via `_day_instants` + `_to_local`.
+- [x] Tests for spring-forward hour=14 and hour=2.
+- [x] Docs updated per coordinated-change rule.

--- a/docs/plans/2026-07-20-pr5-ci-release.md
+++ b/docs/plans/2026-07-20-pr5-ci-release.md
@@ -1,0 +1,319 @@
+# PR 5: CI, release graph, Dependabot, security docs
+
+> **For agentic workers:** Prefer careful, reviewable CI edits. Do not
+> rotate secrets. Checkbox tracking.
+
+**Status:** Proposed
+**Goal:** Reduce supply-chain and half-publish risk; add dependency
+automation; document security and changelog expectations.
+**Architecture:** Split `deployment.yml` into ordered jobs; add
+Dependabot; light docs.
+**Tech stack:** GitHub Actions, Docker Buildx, existing tox.
+
+## Global constraints
+
+See roadmap. No application runtime change. Depends on PR 1
+`.dockerignore` for sensible Docker context (can cherry-pick
+dockerignore if this PR lands first).
+
+## Design decisions
+
+1. **Dependabot** for `github-actions` and `pip` (weekly). Pre-commit
+   already monthly via pre-commit.ci.
+2. **Release jobs:**
+   - `test` — checkout, setup Python, version gate, install, coverage.
+   - `pypi` — needs: test; build + publish (OIDC, environment release).
+   - `docker` — needs: test; build/push (can run **parallel** with pypi
+     after test).
+   **Half-publish note:** PyPI and Docker can still diverge if one fails
+   after both start. **Stricter option (recommended):**
+   `docker` needs `test`; `pypi` needs `test` **and** `docker`
+   so Docker must succeed before PyPI (or reverse: PyPI first is current
+   risk).
+   **Chosen default for this plan:**
+   `test` → then **parallel** `docker` + build artifact; **`pypi` needs
+   both `test` and a `docker` job that builds (and pushes) successfully.**
+   Trade-off: Docker Hub outage blocks PyPI. Acceptable for this project
+   size; document in RELEASE.md.
+   Alternative if maintainer prefers PyPI-first: keep order but add
+   failure notification only — note in PR if overridden.
+3. **Docker smoke:** After build/push (or on a local load for single-arch
+   smoke before push), run:
+
+   ```bash
+   docker run --rm bledy/timezone-converter:… --version
+   docker run --rm bledy/timezone-converter:… tijuana --hour 12
+   ```
+
+   Multi-arch push makes “run” ambiguous; **smoke on `linux/amd64`
+   via buildx `--load` in a dedicated step on ubuntu-latest** before
+   multi-arch push, or smoke against the published amd64 digest after
+   push. **Chosen:** build amd64 with `--load`, smoke, then multi-arch
+   push.
+4. **Action SHA pins:** Optional stretch. With Dependabot on
+   `github-actions`, version tags are acceptable for this PR; add a
+   short comment in RELEASE.md that SHA pinning is optional hardening.
+5. **`develop` branch trigger:** Keep unless maintainer confirms
+   unused; document in PR.
+6. **Python 3.14:** Add to matrix only if `actions/setup-python` and
+   tox env work on all OS runners at implementation time; otherwise open
+   a follow-up issue and skip.
+
+## File map
+
+| File | Change |
+|------|--------|
+| `.github/workflows/deployment.yml` | job graph + docker smoke |
+| `.github/workflows/integration.yml` | optional 3.14; develop note |
+| `.github/dependabot.yml` | create |
+| `SECURITY.md` | create |
+| `CHANGELOG.md` | create skeleton |
+| `RELEASE.md` | job order + changelog reminder |
+| `Dockerfile` | optional comment only; no digest pin required |
+
+---
+
+### Task 1: Dependabot
+
+**Files:**
+- Create: `.github/dependabot.yml`
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+```
+
+- [ ] **Step 1: Add file and commit**
+
+```bash
+git add .github/dependabot.yml
+git commit -m "ci: enable Dependabot for Actions and pip"
+```
+
+---
+
+### Task 2: Restructure deployment workflow
+
+**Files:**
+- Modify: `.github/workflows/deployment.yml`
+- Modify: `RELEASE.md`
+
+- [ ] **Step 1: Rewrite jobs** approximately as:
+
+```yaml
+name: deployment
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Validate release version
+        run: |
+          python - <<'PY'
+          # same version check as today
+          PY
+      - name: Install and test
+        run: |
+          python -m pip install --upgrade pip build -e . -r requirements-dev.txt
+          coverage run -m pytest && coverage report
+
+  docker:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: bledy/timezone-converter
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+      - name: Build amd64 for smoke
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: timezone-converter:smoke
+      - name: Smoke test image
+        run: |
+          docker run --rm timezone-converter:smoke --version
+          docker run --rm timezone-converter:smoke tijuana --hour 12
+      - name: Build and push multi-arch
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  pypi:
+    needs: [test, docker]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build -e . -r requirements-dev.txt
+      - name: Build
+        run: python -m build --sdist --wheel --outdir=dist/ .
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+Adjust `environment: release` placement so OIDC and Docker secrets still
+work (both jobs that need secrets get the environment).
+
+- [ ] **Step 2: Update RELEASE.md** “Automated publishing” section to
+  describe job order: test → docker (smoke + push) → PyPI.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "ci: gate PyPI on tests and Docker smoke/push"
+```
+
+---
+
+### Task 3: SECURITY.md and CHANGELOG.md
+
+**Files:**
+- Create: `SECURITY.md`
+- Create: `CHANGELOG.md`
+- Modify: `RELEASE.md` (link CHANGELOG update step)
+
+`SECURITY.md` minimal:
+
+```markdown
+# Security Policy
+
+## Supported versions
+
+The latest release on PyPI is supported with security fixes.
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately via GitHub Security Advisories
+for this repository (Security → Advisories → New draft advisory), or
+email the maintainer address listed on PyPI/GitHub.
+
+Do not open public issues for unfixed vulnerabilities.
+```
+
+`CHANGELOG.md` skeleton:
+
+```markdown
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+Format inspired by Keep a Changelog. Versions match `pyproject.toml`
+and Git tags.
+
+## Unreleased
+
+### Fixed
+### Added
+### Changed
+### Security
+```
+
+RELEASE.md bullet under “Before creating the release”:
+
+```markdown
+- Update `CHANGELOG.md` (move Unreleased notes into the new version).
+```
+
+- [ ] **Step 1: Add files, commit**
+
+```bash
+git add SECURITY.md CHANGELOG.md RELEASE.md
+git commit -m "docs: add SECURITY policy and changelog skeleton"
+```
+
+---
+
+### Task 4: Integration matrix hygiene
+
+**Files:**
+- Modify: `.github/workflows/integration.yml` only if adding 3.14
+
+- [ ] **Step 1: Probe 3.14 availability** during implementation. If
+  available on ubuntu/mac/windows:
+
+```yaml
+python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+```
+
+And tox `envlist` + `gh-actions` mapping + classifier in pyproject.
+
+If not available on all OS, **skip** and leave a short note in the PR
+body / CHANGELOG Unreleased “Planned”.
+
+- [ ] **Step 2: Commit only if 3.14 added.**
+
+---
+
+### Task 5: Verification
+
+- [ ] Validate YAML:
+
+```bash
+# if actionlint available
+actionlint .github/workflows/*.yml || true
+python -c "import yaml,sys; yaml.safe_load(open('.github/dependabot.yml'))"
+```
+
+- [ ] Open PR
+  `ci: Dependabot, safer release graph, security and changelog docs`
+
+## Out-of-band (do not automate in this PR)
+
+- Delete stale remote branches (`claude/*`, old features) after human review.
+- Rotate Docker Hub tokens.
+- Pin base image digests (optional follow-up).
+
+## Self-review checklist
+
+- [x] Half-publish risk addressed via job `needs`.
+- [x] Docker smoke defined.
+- [x] Dependabot + SECURITY + CHANGELOG.
+- [x] 3.14 gated on runner reality.

--- a/docs/plans/2026-07-20-pr6-product-enhancements.md
+++ b/docs/plans/2026-07-20-pr6-product-enhancements.md
@@ -1,0 +1,168 @@
+# PR 6: Product enhancements (optional track)
+
+> **For agentic workers:** Implement only after PR 1–5 (or as
+> separate feature PRs split further). Each feature below can be its
+> **own PR** if preferred. Checkbox tracking. Coordinated CLI changes
+> required per AGENTS.md.
+
+**Status:** Proposed
+**Goal:** Deliver audit “later / product” items: fixed date, local
+override, machine-readable output, ambiguous short-name feedback.
+**Architecture:** Extend `ComparisonView` construction and `main`
+parser; keep DST-aware instant building. Prefer small flags over
+subcommands.
+**Tech stack:** argparse, zoneinfo, Rich (human), json module (machine).
+
+## Global constraints
+
+See roadmap. Each flag: parser + dispatch + view + tests + README + tox
+smoke + AGENTS. Python 3.9 typing. 100% coverage.
+
+## Features (implement in this order)
+
+### Feature A — `--date YYYY-MM-DD`
+
+**Semantics:** Set comparison local calendar day to the given date
+instead of today. `base_instant` becomes local midnight on that date
+(via `_to_local` / system or `--local` zone).
+
+**Parser:**
+
+```python
+def _date_value(argument: str) -> datetime.date:
+    try:
+        return datetime.strptime(argument, '%Y-%m-%d').date()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            'Value for --date must be YYYY-MM-DD',
+        ) from exc
+
+parser.add_argument(
+    '--date',
+    type=_date_value,
+    metavar='YYYY-MM-DD',
+    help='local calendar date to compare (default: today)',
+)
+```
+
+**ComparisonView:** accept `Optional[date]`; if set, build
+`base_instant` from that date at midnight in the local zone.
+
+**Tests:** fixed date with monkeypatched local zone; DST date
+2026-03-08 with `--hour 14` after PR 4.
+
+**Tox smoke:** `timezone-converter tijuana --date 2026-01-15 --hour 12`
+
+---
+
+### Feature B — `--local TIMEZONE`
+
+**Semantics:** Override the LOCAL column’s zone (and local midnight)
+instead of the host system zone. Critical for Docker (`UTC` host).
+
+**Implementation sketch:**
+
+- Resolve name via `Helper.resolve_timezone`.
+- Patch comparison to use `ZoneInfo(name)` wherever `_to_local` is used
+  for “local”, **or** pass `local_zone: Optional[tzinfo]` into
+  ComparisonView and replace `_to_local(instant)` with
+  `instant.astimezone(local_zone)` when set.
+- Prefer injecting local zone into ComparisonView over global
+  monkeypatch in production code.
+
+**Tests:** `--local utc` with foreign `new_york` yields stable headers
+independent of host TZ.
+
+**Tox smoke:** `timezone-converter new_york --local utc --hour 0`
+
+---
+
+### Feature C — `--format {table,json}` (default table)
+
+**Semantics:**
+
+- `table` — current Rich table (default).
+- `json` — stdout JSON array of row objects:
+  `{"local": "...", "America/New_York": "...", ...}` with ISO-like
+  strings matching table cells (`%Y-%m-%d %H:%M`) **or** true ISO-8601
+  offsets — **choose one and document**. Recommended: same strings as
+  table for parity, plus a top-level `"headers"` list.
+
+**Rules:**
+
+- JSON mode should not use Rich color; print plain JSON to stdout.
+- Errors still stderr + nonzero exit.
+- Highlighting is table-only (omit from JSON).
+
+**Tests:** parse JSON with `json.loads`; one-hour mode single element.
+
+**Tox smoke:** `timezone-converter tijuana --hour 8 --format json`
+
+---
+
+### Feature D — Ambiguous short-name warning
+
+**Semantics:** When the user passes a short segment that appears in
+`_AMBIGUOUS_SEGMENTS` (e.g. `istanbul`), resolve as today (last-wins /
+current `resolve_timezone` behavior) but print a **stderr** warning
+listing canonical alternatives and the chosen zone:
+
+```
+warning: 'istanbul' is ambiguous; using Europe/Istanbul. Also available: Asia/Istanbul, Europe/Istanbul
+```
+
+Do not warn when user passes a full path.
+
+**Tests:** capsys stderr for `istanbul`; no warning for
+`Europe/Istanbul`.
+
+**Optional stricter mode (out of scope unless requested):**
+`--strict-ambiguous` exits 1.
+
+---
+
+## File map (all features)
+
+| File | Role |
+|------|------|
+| `timezone_converter/main.py` | flags + dispatch |
+| `timezone_converter/comparison_view.py` | date/local/format |
+| `timezone_converter/helper.py` | ambiguous warning helper |
+| `tests/comparison_view_test.py` | core behavior |
+| `tests/main_test.py` | parser |
+| `README.md` / `AGENTS.md` / tox in `pyproject.toml` | coordinated updates |
+| `CHANGELOG.md` | Unreleased notes per feature |
+
+## Suggested PR split
+
+| PR | Contents |
+|----|----------|
+| 6a | `--date` |
+| 6b | `--local` |
+| 6c | `--format json` |
+| 6d | ambiguous short-name warning |
+
+Each gets its own branch: `grok/feat-date`, etc.
+
+## Task template (repeat per feature)
+
+- [ ] **Step 1:** Write failing parser + view tests.
+- [ ] **Step 2:** Implement minimal code (3.9 typing, MyPy clean).
+- [ ] **Step 3:** Update README feature section + examples.
+- [ ] **Step 4:** Add tox smoke command(s).
+- [ ] **Step 5:** `coverage run -m pytest && coverage report` → 100%.
+- [ ] **Step 6:** `pre-commit run --all-files`.
+- [ ] **Step 7:** Commit with Conventional Commit
+  (`feat: add --date for fixed local calendar day`).
+- [ ] **Step 8:** Open PR; mark ready when CI green.
+
+## Versioning
+
+- Features A–C → minor version bumps when released (can batch).
+- Feature D → minor or patch; document under Changed/Fixed.
+
+## Self-review checklist
+
+- [x] All audit “product later” items represented.
+- [x] Split guidance avoids one mega-PR.
+- [x] DST and Docker local override called out.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,14 @@
+# Plans index
+
+| Plan | Status | Purpose |
+|------|--------|---------|
+| [2026-07-20-audit-remediation-roadmap.md](./2026-07-20-audit-remediation-roadmap.md) | Proposed | Master map of audit → PRs |
+| [2026-07-20-pr1-hygiene-docs.md](./2026-07-20-pr1-hygiene-docs.md) | Proposed | Ignores, dead hooks, docstrings |
+| [2026-07-20-pr2-packaging.md](./2026-07-20-pr2-packaging.md) | Proposed | `py.typed`, `__main__`, dev extras |
+| [2026-07-20-pr3-cli-robustness.md](./2026-07-20-pr3-cli-robustness.md) | Proposed | Version, modes, stderr exits |
+| [2026-07-20-pr4-hour-wall-clock.md](./2026-07-20-pr4-hour-wall-clock.md) | Proposed | `--hour` wall-clock (behavior change) |
+| [2026-07-20-pr5-ci-release.md](./2026-07-20-pr5-ci-release.md) | Proposed | Dependabot, release graph, SECURITY |
+| [2026-07-20-pr6-product-enhancements.md](./2026-07-20-pr6-product-enhancements.md) | Proposed | Optional `--date`/`--local`/JSON/… |
+
+Execute in order **1 → 5** for full audit remediation; **6** is product
+follow-up and may be split into 6a–6d.


### PR DESCRIPTION
## Summary

Adds implementation plans covering every item from the full repository audit:

1. **PR1** — Hygiene (dockerignore/gitignore, dead hooks, docstring drift)
2. **PR2** — Packaging (`py.typed`, `__main__`, dev extras)
3. **PR3** — CLI robustness (safe `--version`, exclusive modes, stderr errors)
4. **PR4** — `--hour` as local wall-clock (DST-safe behavior change)
5. **PR5** — CI/release hardening (Dependabot, job graph, SECURITY/CHANGELOG)
6. **PR6** — Optional product track (`--date`, `--local`, JSON, ambiguous names)

Entry point: `docs/plans/README.md` and `docs/plans/2026-07-20-audit-remediation-roadmap.md`.

## Test plan

- [x] Plans are Markdown only; no runtime code changes
- [x] `pre-commit run --all-files` passes on this branch after whitespace fix
- [ ] Review roadmap order and locked design decisions (especially PR3 exclusivity and PR4 gap/fold policy)
- [ ] Approve or adjust PR5 default (PyPI gated on Docker success)