### PR TITLE
chore: Docker/git ignore hygiene and docstring drift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,12 @@
 build
 dist
 requirements-dev.txt
-test
+tests
+docs
+AGENTS.md
+CLAUDE.md
+RELEASE.md
+.coverage
+htmlcov
+coverage.xml
+.ruff_cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ __pycache__
 build
 dist
 test
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+.ruff_cache/
+.dmypy.json
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,13 +55,6 @@ repos:
       - id: remove-crlf
       - id: remove-tabs
 
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v3.2.0
-    hooks:
-      - id: setup-cfg-fmt
-        args:
-          - "--include-version-classifiers"
-
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ data comes from `zoneinfo` plus `tzdata`; avoid platform-specific behavior.
 ## Commands
 
 - Install: `pip install -e .` and `pip install -r requirements-dev.txt`
-- Run: `timezone-converter <timezone> [<timezone> ...]` or
+- Run: `timezone-converter` or `tzconv` `<timezone> [<timezone> ...]` or
   `python -m timezone_converter.main`
 - Test: `pytest` (or `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` when global
   plugins interfere)

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -53,6 +53,9 @@ class ComparisonView(Helper):
         order : bool
             If ``True``, sort the foreign timezones by absolute offset
             from the local timezone.
+        difference : bool
+            If ``True``, append each foreign column's signed hour offset
+            from the local timezone to the header (e.g. ``+5h``).
 
         Raises
         ------

--- a/timezone_converter/main.py
+++ b/timezone_converter/main.py
@@ -38,7 +38,8 @@ def build_parser() -> argparse.ArgumentParser:
     -------
     argparse.ArgumentParser
         Parser configured with the ``timezone``, ``--list``, ``--version``,
-        ``--zone``, ``--single``, ``--search``, and ``--order`` arguments.
+        ``--zone``, ``--hour``, ``--search``, ``--order``, and
+        ``--difference`` arguments.
     """
     parser = argparse.ArgumentParser(
         prog='timezone-converter',


### PR DESCRIPTION
## Summary

Audit remediation **PR1** (hygiene only — no runtime behavior change):

- **`.dockerignore`**: ignore `tests/` (was bare `test`), docs, agent files, coverage caches
- **`.gitignore`**: ignore coverage artifacts and local tool caches (includes the intent of #80)
- **pre-commit**: remove unused `setup-cfg-fmt` (no `setup.cfg` in this repo)
- **Docstrings**: `build_parser` no longer mentions `--single`; document `--hour` / `--difference`; `ComparisonView` documents `difference`
- **AGENTS/CLAUDE**: document `tzconv` entry point

## Overlap

Open PR #80 only adds coverage lines to `.gitignore`. This PR covers that and more; prefer merging this and closing #80, or rebase #80 away after this lands.

## Test plan

- [x] `coverage run -m pytest && coverage report` — 100%
- [x] `pre-commit run --all-files`
- [ ] Confirm Docker context no longer needs tests (optional local `docker build`)