### PR TITLE
docs: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something is wrong with timezone conversion, CLI, or packaging
+title: ''
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- Clear description of the bug -->
+
+## Expected behavior
+
+## How to reproduce
+
+```bash
+timezone-converter …
+```
+
+## Environment
+
+- OS:
+- Python version:
+- Package version (`timezone-converter --version`):
+- Install method (pip / Docker / editable):
+
+## Extra context
+
+<!-- Screenshots, full output, DST date if relevant -->
+
+## Security
+
+For vulnerabilities, do **not** use this form. Prefer a private GitHub Security
+Advisory or the maintainer contact on the repo/PyPI.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a CLI or packaging improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What is hard or missing today? -->
+
+## Proposal
+
+<!-- Concrete behavior, flags, or UX -->
+
+## Alternatives considered
+
+## Scope notes
+
+- [ ] User-facing CLI change (needs README + tox smoke per AGENTS.md)
+- [ ] Breaking change (label `breaking` if yes)
+- [ ] Docker / release impact

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What and why. Link issues with Fixes #N / Refs #N. -->
+
+## Test plan
+
+- [ ] `coverage run -m pytest && coverage report` (100%)
+- [ ] `pre-commit run --all-files` (or CI equivalent)
+- [ ] CLI smoke for any new/changed flags (see tox commands in `pyproject.toml`)
+
+## Checklist
+
+- [ ] Coordinated docs if CLI flags or behavior changed (README, AGENTS if needed)
+- [ ] DST-sensitive changes include spring-forward and fall-back tests
+- [ ] No secrets or local paths committed
+
+## Breaking change?
+
+- [ ] No
+- [ ] Yes — describe migration / label `breaking`


### PR DESCRIPTION
## Summary

Minimal bug/feature issue templates and a PR checklist (coverage, pre-commit, CLI coordination, DST tests, breaking-change callout).

Closes #93

## Test plan

- [x] Templates are Markdown only
- [x] Confirm GitHub UI shows forms after merge