### PR TITLE
Fix --hour selecting the wrong instant on DST transition days

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ abbreviation, e.g. `AMERICA/TIJUANA (PST) -8h`.
 Using the `--hour` argument, you can output a single hour. If you don't
 provide a value, the current hour will be displayed.
 
+The value is a local wall-clock hour, so on the days your clocks change it
+still refers to the hour you actually see on the clock. When your clocks fall
+back, the repeated hour happens twice and both instants are shown. When they
+spring forward, the skipped hour never happens, and asking for it is an error.
+
 ### Search for a timezone
 
 Using the `--search` argument, you can fuzzy-search for available timezone

--- a/tests/comparison_view_test.py
+++ b/tests/comparison_view_test.py
@@ -263,6 +263,52 @@ def test_hour_builds_one_row():
     assert len(view._build_table().rows) == 1
 
 
+def _hour_column(day, zone, hour):
+    year, month, day_of_month = day
+    view = _make_view(['london'], hour=hour)
+    view.base_instant = datetime(year, month, day_of_month, tzinfo=zone)
+    return list(view._build_table().columns[0]._cells)
+
+
+def test_hour_selects_local_wall_clock_hour_on_spring_forward_day(local_timezone):
+    # Regression: --hour was computed as "N real hours after local midnight"
+    # (base_utc + timedelta(hours=N)), so every hour past a spring-forward
+    # transition was rendered an hour late -- --hour 14 showed 15:00.
+    zone = local_timezone('America/New_York')
+    assert _hour_column((2026, 3, 8), zone, 14) == ['2026-03-08 14:00']
+
+
+def test_hour_selects_local_wall_clock_hour_on_fall_back_day(local_timezone):
+    # Regression companion: the same arithmetic drifted the other way after a
+    # fall-back transition -- --hour 14 showed 13:00.
+    zone = local_timezone('America/New_York')
+    assert _hour_column((2026, 11, 1), zone, 14) == ['2026-11-01 14:00']
+
+
+def test_hour_does_not_spill_into_the_next_day_on_spring_forward(local_timezone):
+    # Regression: on a 23-hour day the old arithmetic pushed --hour 23 past
+    # midnight into the following date.
+    zone = local_timezone('America/New_York')
+    assert _hour_column((2026, 3, 8), zone, 23) == ['2026-03-08 23:00']
+
+
+def test_hour_shows_both_instants_of_a_repeated_local_hour(local_timezone):
+    # A fall-back day lives through 01:00 twice; both instants are real, so
+    # both are shown, matching how the full-day table renders the repeat.
+    zone = local_timezone('America/New_York')
+    assert _hour_column((2026, 11, 1), zone, 1) == [
+        '2026-11-01 01:00',
+        '2026-11-01 01:00',
+    ]
+
+
+def test_hour_skipped_by_spring_forward_exits(local_timezone):
+    # 02:00 never happens on this date; an empty table would be misleading.
+    zone = local_timezone('America/New_York')
+    with pytest.raises(SystemExit, match='does not exist'):
+        _hour_column((2026, 3, 8), zone, 2)
+
+
 def test_current_hour_row_is_highlighted():
     view = _make_view(['new_york'])
     styles = [row.style for row in view._build_table().rows]
@@ -337,14 +383,17 @@ def test_half_hour_dst_offset_still_yields_a_24_row_spring_forward_day(
     assert all(cell.startswith('2026-10-04') for cell in cells)
 
 
-def test_hour_zero_produces_single_row_not_full_day():
+def test_hour_zero_produces_single_row_not_full_day(local_timezone):
     # Boundary regression: hour=0 is falsy in Python, so a bug that checks
     # ``if self.hour:`` instead of ``if self.hour is not None:`` would
     # silently render the full day table instead of the single midnight row.
     # Combined with --zone to also confirm the abbreviation header still
     # reflects the base instant's DST state at the boundary.
+    # ``base_instant`` is always local midnight in production, so the local
+    # zone is pinned to match it rather than left as the machine's.
+    zone = local_timezone('America/New_York')
     view = _make_view(['new_york'], hour=0, zone=True)
-    view.base_instant = datetime(2026, 6, 1, tzinfo=ZoneInfo('America/New_York'))
+    view.base_instant = datetime(2026, 6, 1, tzinfo=zone)
     table = view._build_table()
     assert len(table.rows) == 1
     assert list(table.columns[1]._cells) == ['2026-06-01 00:00']

--- a/timezone_converter/comparison_view.py
+++ b/timezone_converter/comparison_view.py
@@ -48,8 +48,8 @@ class ComparisonView(Helper):
             If ``True``, include the resolved zone name (and current tz
             abbreviation) in each column header.
         hour : Optional[int]
-            If given, restrict the table to this single hour (0-23)
-            instead of the full local day.
+            If given, restrict the table to this local wall-clock hour
+            (0-23) instead of the full local day.
         order : bool
             If ``True``, sort the foreign timezones by absolute offset
             from the local timezone.
@@ -165,17 +165,38 @@ class ComparisonView(Helper):
             instant = base_utc + timedelta(hours=hour)
         return instants
 
+    def _selected_instants(self) -> List[datetime]:
+        # ``--hour N`` means "the local wall-clock hour N", which is not the
+        # same as "N real hours after local midnight". On a spring-forward day
+        # those drift apart by an hour for every hour past the transition, and
+        # on a fall-back day they drift the other way, so the hour has to be
+        # picked out of the real local day rather than computed by arithmetic.
+        instants = self._day_instants()
+        if self.hour is None:
+            return instants
+
+        # A fall-back day repeats a local hour, so this can legitimately match
+        # twice; both instants are shown, matching the full-day table.
+        matching = [
+            instant for instant in instants if _to_local(instant).hour == self.hour
+        ]
+        if not matching:
+            # A spring-forward day skips a local hour entirely; there is no
+            # instant to show, so say so instead of rendering an empty table.
+            raise SystemExit(
+                f'error: {self.hour:02d}:00 does not exist on '
+                f'{_to_local(self.base_instant).date()} in your local timezone, '
+                'the clocks skip forward over it',
+            )
+        return matching
+
     def _build_table(self) -> Table:
         headers = self._get_headers()
         table = Table()
         for header in headers:
             table.add_column(header, justify='center')
 
-        if self.hour is not None:
-            base_utc = self.base_instant.astimezone(datetime_timezone.utc)
-            instants: List[datetime] = [base_utc + timedelta(hours=self.hour)]
-        else:
-            instants = self._day_instants()
+        instants = self._selected_instants()
 
         fmt = '%Y-%m-%d %H:%M'
         now = datetime.now().astimezone()


### PR DESCRIPTION
## Summary

Routine audit of the repo (re-reading `AGENTS.md`, checking open issues/PRs, running tests/coverage/mypy) surfaced issue #81 (P0, `bug`/`breaking`): `--hour N` was resolved as `base_utc + timedelta(hours=N)` — "N real hours after local midnight" — which only matches the local wall-clock hour N on days with 24 equal hours. On a spring-forward day every hour past the transition rendered an hour late (`--hour 14` showed `15:00`), and `--hour 23` could spill into the next date; on a fall-back day the drift ran the other way.

Issue #81 pointed at prior work already sitting on an unmerged branch (`claude/timezone-converter-v1-readiness-h4ddd4`, commit `fa32715`) that was never landed. This PR cherry-picks and lands that fix rather than reinventing it:

- Picks the hour out of the real local day produced by `_day_instants()` instead of doing UTC-offset arithmetic.
- A repeated fall-back hour now shows both instants, matching the full-day table.
- An hour skipped by spring-forward now exits with a clear error instead of rendering an empty table.
- Documents the DST behavior of `--hour` in the README.

Fixes #81.

## Test plan

- [x] `coverage run -m pytest && coverage report` (100%, 65 tests passing)
- [x] `mypy timezone_converter` (no issues)
- [x] CLI smoke for `--hour` across spring-forward/fall-back regression tests

## Checklist

- [x] Coordinated docs if CLI flags or behavior changed (README)
- [x] DST-sensitive changes include spring-forward and fall-back tests
- [x] No secrets or local paths committed

## Breaking change?

- [x] Yes — `--hour N` now refers to the local wall-clock hour rather than "N hours after local midnight". These only differ on DST transition days, where the old behavior was already producing incorrect output. Already labeled `breaking` on the tracking issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SANPw5QuJCqpzRaexLrMxv)_